### PR TITLE
Refine PLAN: explicit backend fallback policy and default-feature documentation

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -30,19 +30,19 @@ These items make the crate a credible alternative to existing options.
 
 **Priority: Critical — this is the moat**
 
-Try the XDG GlobalShortcuts portal first (no root needed, works on KDE,
-GNOME 48+, Hyprland). Fall back to evdev when the portal is unavailable
-(Sway, wlroots, X11, TTY, headless).
+Try the XDG GlobalShortcuts portal first (no root needed where available).
+Fall back to evdev when the portal is unavailable or unsupported (common on
+Sway/wlroots, TTY, headless, and some compositor/portal combinations).
 
-| Environment          | Backend selected | Root needed? |
-|----------------------|------------------|--------------|
-| KDE Plasma (Wayland) | Portal           | No           |
-| GNOME 48+ (Wayland)  | Portal           | No           |
-| Hyprland             | Portal           | No           |
-| Sway / wlroots       | evdev            | input group  |
-| X11                  | evdev            | input group  |
-| TTY / headless       | evdev            | input group  |
-| Flatpak / sandboxed  | Portal           | No           |
+| Environment          | Preferred backend | Notes |
+|----------------------|-------------------|-------|
+| KDE Plasma (Wayland) | Portal            | Use portal when GlobalShortcuts is implemented by the session. |
+| GNOME (Wayland)      | Portal            | Must gracefully fall back if the interface is missing/disabled. |
+| Hyprland             | Portal            | Depends on portal backend support; fall back automatically otherwise. |
+| Sway / wlroots       | evdev             | Usually no GlobalShortcuts support today. |
+| X11                  | evdev             | Portal often unavailable for this use case. |
+| TTY / headless       | evdev             | No desktop portal expected. |
+| Flatpak / sandboxed  | Portal            | Primary path when host exposes the portal. |
 
 Architecture:
 
@@ -59,10 +59,18 @@ struct PortalBackend { /* ashpd / zbus */ }
 struct EvdevBackend  { /* current implementation */ }
 ```
 
-The public `HotkeyManager::new()` probes for the portal via D-Bus. If the
-compositor responds and supports GlobalShortcuts, use `PortalBackend`.
-Otherwise, fall back to `EvdevBackend`. The caller never needs to know which
-backend is active.
+The public `HotkeyManager::new()` probes for the portal via D-Bus (when the
+`portal` feature is enabled). If the compositor responds and supports
+GlobalShortcuts, use `PortalBackend`. Otherwise, fall back to `EvdevBackend`.
+The caller never needs to know which backend is active.
+
+Important initialization rule: **backend probing must happen before evdev
+permission checks**. If portal is selected, manager creation must not fail due
+to missing `input` group membership.
+
+Permission checks should validate actual device access capability (or attempt to
+open candidate event devices) rather than relying only on group-name heuristics
+so environments with ACLs/capabilities behave correctly.
 
 Users who need a specific backend can opt in:
 
@@ -73,6 +81,13 @@ HotkeyManager::with_backend(Backend::Portal)?;
 
 Dependencies: `ashpd` (XDG portal bindings), `zbus` (D-Bus). These should be
 behind a `portal` feature flag so pure-evdev users don't pay the cost.
+
+Backend selection must respect compile-time availability:
+- if both `portal` and `evdev` are compiled, use runtime probing/fallback
+- if only one backend is compiled, use it directly
+- if requested backend is not compiled in, return a clear feature-disabled error
+- do not silently fall back when the caller explicitly requests a backend;
+  return the backend-specific initialization error instead
 
 ### 1.2 Release / hold events
 
@@ -130,6 +145,11 @@ Add `Error::AlreadyRegistered` variant. Provide `manager.is_registered()` for
 checking before registering. Provide `manager.replace()` for intentional
 overwrites.
 
+Conflict checks must use the same modifier-normalization rules as runtime
+matching. In particular, left/right variants (Ctrl/Alt/Shift/Meta) should be
+canonicalized so semantically equivalent registrations cannot coexist and cause
+non-deterministic callback selection.
+
 ### 1.5 Device hotplug
 
 **Priority: High — reliability**
@@ -140,6 +160,23 @@ handle this without restarting.
 Use `inotify` to watch `/dev/input` for new `event*` files. When a new device
 appears, probe it for keyboard capabilities and add it to the listener. When a
 device disappears (fd returns errors), remove it from the poll set.
+
+Hotplug handling must also repair key/modifier state on disconnect. If a
+device vanishes while keys are held, synthesize release/state cleanup so
+modifiers do not get stuck active.
+
+### 1.6 Event loop architecture (latency + CPU correctness)
+
+**Priority: High — production behavior**
+
+The current polling-style listener design is simple but can waste CPU and add
+latency jitter under load. Move to a poll/epoll-driven wait model for device
+FDs and hotplug notifications so callbacks fire promptly without busy waiting.
+
+Requirements:
+- No fixed sleep-based busy loop in steady state
+- Bounded shutdown latency when stop is requested
+- Deterministic behavior when many events arrive in bursts
 
 ---
 
@@ -169,14 +206,22 @@ manager.register_sequence(
 )?;
 ```
 
+Note: this requires explicit support for modifier-only sequence steps. If that
+support is deferred, the leader-key example should use a non-modifier key.
+
 Implementation: a state machine per registered sequence. On partial match,
 start a timer. If the next step matches before timeout, advance. If timeout
 expires or wrong key, reset. The `timeout_key` option (from xremap) lets you
 specify what to emit when a partial sequence times out.
 
+If `timeout_key` is supported, document backend behavior explicitly: evdev can
+emit via uinput, while portal-only sessions should either reject this option or
+degrade predictably with a clear error.
+
 Edge cases to handle:
 - Overlapping prefixes (`Ctrl+K` is both a standalone hotkey and the first
   step of `Ctrl+K, Ctrl+C`) — standalone fires on timeout if no second step
+  (and provide an option for immediate standalone firing for low-latency binds)
 - Multiple active sequences — track independently
 - Sequence cancelled by pressing Escape (configurable abort key)
 
@@ -209,8 +254,8 @@ This is what makes keyd and xremap powerful. The evdev crate already exposes
 events — the `evdev` crate's `UinputDevice` or the `uinput` crate can handle
 this.
 
-Only available with the evdev backend (the portal backend inherently handles
-grab at the compositor level).
+Only available with the evdev backend. The portal backend should return a
+clear `UnsupportedFeature`-style error when grab/interception is requested.
 
 ### 2.3 Modes / layers
 
@@ -248,9 +293,10 @@ Mode options (from swhkd):
 - `swallow` — suppress all non-matching events while in this mode
 - `timeout` — auto-pop after N seconds of inactivity
 
-Implementation: the registration HashMap becomes a stack of HashMaps. Hotkey
-lookup checks the top layer first, then falls through to lower layers.
-Mode transitions are just push/pop on the stack.
+Implementation: maintain a stack of layers. Each layer stores exact hotkey
+bindings, and lookup checks from top to bottom. This avoids `HashMap` key
+collisions and supports same key combos in different modes by design. Mode
+transitions are push/pop operations on that stack.
 
 ### 2.4 Device-specific hotkeys
 
@@ -280,6 +326,11 @@ Use cases: macro pads, secondary keyboards, foot pedals. The listener loop
 already iterates per-device — just need to tag events with their source device
 and filter registrations accordingly.
 
+Device-scoped matching also requires device-scoped key state. Modifier tracking
+must be maintained per device (with a safe aggregate view for global binds) so
+a modifier held on keyboard A does not accidentally satisfy a hotkey bound to
+keyboard B.
+
 ### 2.5 Tap vs. hold (dual-function keys)
 
 **Priority: Medium — popular in keyboard community**
@@ -298,8 +349,11 @@ manager.register_tap_hold(
 
 Requires event grabbing (Phase 2.2) since we need to intercept the key and
 decide whether to re-emit it as the tap action or apply it as a modifier.
-The timing heuristic follows keyd's model: resolve as "hold" if another key
-is pressed while the key is down, or if held past the threshold duration.
+This feature depends on synthetic event emission in the evdev backend (via
+uinput) and should return a clear unsupported-feature error on backends that
+cannot safely emulate tap/hold behavior. The timing heuristic follows keyd's
+model: resolve as "hold" if another key is pressed while the key is down, or
+if held past the threshold duration.
 
 ---
 
@@ -359,6 +413,22 @@ writing parsing code.
 
 ---
 
+## Cross-cutting architecture constraints
+
+These constraints apply across phases and should guide all implementations:
+
+- **Deterministic fallback policy**: backend selection should be predictable and
+  inspectable (`manager.active_backend()` or equivalent), so debugging
+  environment-specific behavior is straightforward.
+- **Feature-gated behavior must be explicit**: when `portal` or `grab` features
+  are disabled at compile time, API errors/messages should explain that the
+  capability is not compiled in (not just "unavailable").
+- **Modifier state correctness across devices**: track modifier state in a way
+  that tolerates multiple keyboards and disconnects without producing sticky
+  modifiers or phantom releases.
+
+---
+
 ## Feature flags
 
 ```toml
@@ -375,6 +445,15 @@ serde = ["dep:serde"]
 Pure evdev users get a minimal dependency tree. Portal users opt in.
 Grab mode pulls in uinput. Async is optional.
 
+Define expected behavior for feature combinations in docs/tests (e.g.
+`--no-default-features --features portal`, `--features evdev,portal`, and
+invalid requests like grab without evdev) so compile-time/runtime behavior is
+unambiguous.
+
+Decide and document a release policy for default features (`evdev`-minimal vs
+`full`) so README examples and user expectations align with what is enabled
+out-of-the-box.
+
 ---
 
 ## Non-goals (for now)
@@ -384,8 +463,9 @@ Things this crate will NOT do in Phases 1–3:
 - **Key remapping**: This is a hotkey library, not a remapper. Use keyd or
   xremap for full remapping.
 - **Text expansion / hotstrings**: Out of scope. Different problem domain.
-- **Input simulation / synthetic events**: Out of scope except for uinput
-  re-emission in grab mode.
+- **General-purpose input simulation / macro playback**: Out of scope.
+  Synthetic events are allowed only when required for explicit hotkey features
+  (e.g., grab passthrough, timeout-key fallback, tap-hold resolution).
 - **GUI / system tray**: This is a library, not a daemon.
 
 ### Cross-platform: door is open
@@ -417,7 +497,9 @@ Phase 1 (foundation):
   1.3  String parsing
   1.4  Conflict detection
   1.5  Device hotplug
-  1.1b Portal backend (behind feature flag)
+  1.6  Event loop architecture (poll/epoll + clean shutdown path)
+  1.1b Portal backend (behind feature flag, but required before 1.0 to satisfy
+       unified-backend promise)
 
 Phase 2 (power features):
   2.1  Key sequences / chords
@@ -441,3 +523,34 @@ Phase 4 (expansion — not committed, but the door is open):
 Phase 1 makes the crate publishable. Phase 2 makes it the obvious choice.
 Phase 3 makes it production-ready for demanding applications.
 Phase 4 is an option, not a promise — pursue it if the API proves itself.
+
+---
+
+## Definition of done (quality gates)
+
+Because this is not an MVP, each major item must meet explicit acceptance
+criteria before it is considered complete:
+
+1. **Behavioral tests**
+   - Unit tests for parser/state-machine logic and edge cases.
+   - Integration tests for register/unregister semantics and conflict errors.
+   - Feature-gated tests for portal/grab behavior where supported.
+   - CI coverage across key feature matrices to catch compile-time gating
+     regressions.
+2. **Failure-mode coverage**
+   - Explicit error variants for backend selection failures, unsupported
+     features, permission denial, and device disconnects.
+   - No silent downgrade that changes security behavior (e.g., grab requested
+     but unavailable).
+3. **Docs parity**
+   - README and rustdoc examples must match current API and feature flags.
+   - Default-feature behavior and opt-in requirements are documented
+     unambiguously (especially portal availability expectations).
+   - Backend-specific caveats documented (portal availability varies by
+     compositor/session).
+4. **Threading/runtime guarantees**
+   - No callback invocation while holding registry locks.
+   - Callback panics must not silently kill hotkey processing; define panic
+     policy (contain/log/disable callback) and test it.
+   - Clean shutdown semantics for listener/backends and deterministic resource
+     cleanup.


### PR DESCRIPTION
### Motivation
- Eliminate ambiguity between runtime backend probing and explicit backend requests to avoid surprising silent fallbacks for power users.  
- Make release-default feature expectations explicit so README examples and CI/tests reflect shipped defaults.  
- Strengthen documentation quality gates to ensure default-feature and opt-in semantics are unambiguous.

### Description
- Added a rule that explicit backend requests (e.g., `with_backend(...)`) must not silently fall back to another backend and must return the backend-specific initialization error when the requested backend is not compiled or available.  
- Required a documented release policy for default features (eg. `evdev`-minimal vs `full`) so user-facing examples and expectations align with what is enabled out-of-the-box.  
- Extended the Docs parity acceptance criteria to require unambiguous documentation of default-feature behavior and opt-in requirements, especially regarding portal availability.

### Testing
- Programmatically applied the edits to `PLAN.md` and inspected the resulting text ranges with line-numbered printing commands to confirm the new rules appear in the intended sections.  
- Performed a file-diff inspection and reviewed the affected ranges around backend selection, feature flags, and definition-of-done sections to verify wording and placement.  
- All verification steps completed successfully and the updated `PLAN.md` reflects the intended clarifications.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996aa5b2a60832c80de78c348f740e4)