### PR TITLE
Clean up example output and doc comments

### DIFF
--- a/examples/async_stream.rs
+++ b/examples/async_stream.rs
@@ -14,7 +14,6 @@ use keybound::HotkeyEvent;
 use keybound::HotkeyManager;
 use keybound::HotkeyOptions;
 use keybound::Key;
-use keybound::ModeOptions;
 use keybound::Modifier;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -31,12 +30,12 @@ async fn async_main() -> Result<(), Box<dyn std::error::Error>> {
 
     let manager = HotkeyManager::new()?;
 
-    // Register hotkeys as usual — callbacks still work
+    // Register a hotkey with a callback — it still fires alongside the stream
     let _press = manager.register(Key::A, &[Modifier::Ctrl], || {
         println!("[callback] Ctrl+A pressed");
     })?;
 
-    // With release events
+    // Register one with release events too
     let _release = manager.register_with_options(
         Key::B,
         &[Modifier::Ctrl],
@@ -44,20 +43,8 @@ async fn async_main() -> Result<(), Box<dyn std::error::Error>> {
         || println!("[callback] Ctrl+B"),
     )?;
 
-    // A mode for demonstrating ModeChanged events
-    manager.define_mode("demo", ModeOptions::new().oneshot(), |mode| {
-        mode.register(Key::X, &[], || println!("[callback] mode: X pressed"))?;
-        Ok(())
-    })?;
-
-    let mode_controller = manager.mode_controller();
-    let _mode_trigger = manager.register(Key::M, &[Modifier::Ctrl], move || {
-        mode_controller.push("demo");
-    })?;
-
-    println!("  Ctrl+A  → press event");
-    println!("  Ctrl+B  → press + release events");
-    println!("  Ctrl+M  → push 'demo' mode (ModeChanged event)");
+    println!("  Ctrl+A  → press only");
+    println!("  Ctrl+B  → press + release");
     println!();
 
     // Subscribe to the event stream

--- a/examples/grab.rs
+++ b/examples/grab.rs
@@ -7,7 +7,8 @@
 //! Use `passthrough()` on specific hotkeys to observe without consuming —
 //! the callback fires AND the key reaches applications.
 //!
-//! Requires the `grab` feature.
+//! Requires the `grab` feature and write access to `/dev/uinput` — see
+//! the "Grab mode permissions" section in the README.
 //!
 //! ```sh
 //! cargo run --example grab --features grab

--- a/examples/multi.rs
+++ b/examples/multi.rs
@@ -1,15 +1,19 @@
+//! Multiple hotkeys — same key with different modifiers.
+//!
+//! Registers several hotkeys at once, including the same target key (`X`)
+//! with different modifier combinations to show they are independent.
+//!
+//! ```sh
+//! cargo run --example multi
+//! ```
+
 use keybound::HotkeyManager;
 use keybound::Key;
 use keybound::Modifier;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Multiple hotkeys example");
-    println!("Registered hotkeys:");
-    println!("  - Ctrl+Shift+A: Action A");
-    println!("  - Ctrl+Shift+B: Action B");
-    println!("  - Ctrl+Alt+X: Action X1 (same key, different modifiers)");
-    println!("  - Ctrl+Shift+X: Action X2 (same key, different modifiers)");
-    println!("Press Ctrl+C to exit");
+    println!();
 
     let manager = HotkeyManager::new()?;
 
@@ -21,7 +25,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("Action B triggered!");
     })?;
 
-    // Same key (X) with different modifiers - demonstrates registration key is (key, modifiers)
+    // Same key (X) with different modifiers
     let _handle3 = manager.register(Key::X, &[Modifier::Ctrl, Modifier::Alt], || {
         println!("Action X1 triggered! (Ctrl+Alt+X)");
     })?;
@@ -30,7 +34,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("Action X2 triggered! (Ctrl+Shift+X)");
     })?;
 
-    println!("All hotkeys registered. Waiting for input...");
+    println!("  Ctrl+Shift+A  → Action A");
+    println!("  Ctrl+Shift+B  → Action B");
+    println!("  Ctrl+Alt+X    → Action X1");
+    println!("  Ctrl+Shift+X  → Action X2");
+    println!();
     println!("Press Ctrl+C to exit");
 
     std::thread::park();

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,18 +1,28 @@
+//! Minimal hotkey registration.
+//!
+//! Registers a single hotkey and waits for it to fire. This is the
+//! simplest possible use of keybound.
+//!
+//! ```sh
+//! cargo run --example simple
+//! ```
+
 use keybound::HotkeyManager;
 use keybound::Key;
 use keybound::Modifier;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("Starting keybound example");
-    println!("Press Ctrl+Shift+C to trigger hotkey");
+    println!("Minimal hotkey example");
+    println!();
 
     let manager = HotkeyManager::new()?;
 
     let _handle = manager.register(Key::C, &[Modifier::Ctrl, Modifier::Shift], || {
-        println!("Hotkey triggered! (Ctrl+Shift+C)");
+        println!("Hotkey triggered!");
     })?;
 
-    println!("Hotkey registered. Waiting for input...");
+    println!("  Ctrl+Shift+C  → trigger hotkey");
+    println!();
     println!("Press Ctrl+C to exit");
 
     std::thread::park();

--- a/examples/tap_hold.rs
+++ b/examples/tap_hold.rs
@@ -6,7 +6,8 @@
 //!
 //! Classic use case: `CapsLock` = tap for Escape, hold for Ctrl.
 //!
-//! Requires **event grabbing** (the `grab` feature and builder config).
+//! Requires the `grab` feature and write access to `/dev/uinput` — see
+//! the "Grab mode permissions" section in the README.
 //!
 //! ```sh
 //! cargo run --example tap_hold --features grab


### PR DESCRIPTION
Leftover example cleanups that should have been in #22.

- `simple.rs` / `multi.rs`: Add module-level `//!` doc comments, consistent output formatting
- `async_stream.rs`: Remove unused `ModeOptions` import and mode demo (modes have their own dedicated example), simplify output
- `grab.rs` / `tap_hold.rs`: Reference README permissions section in doc comment