### PR TITLE
Implement RAII drop for Handle, SequenceHandle, and TapHoldHandle

### DIFF
--- a/examples/conflict_detection.rs
+++ b/examples/conflict_detection.rs
@@ -2,7 +2,8 @@
 //!
 //! keybound prevents duplicate registrations by default and returns a clear
 //! error. Use `replace()` to intentionally swap a callback, or call
-//! `handle.unregister()` to explicitly remove a registration.
+//! `handle.unregister()` to explicitly remove a registration. Handles also
+//! unregister automatically when the last clone is dropped.
 //!
 //! ```sh
 //! cargo run --example conflict_detection

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -323,11 +323,11 @@ impl HotkeyManager {
             };
         }
 
-        Ok(Handle {
-            location: RegistrationLocation::Global(hotkey_key),
+        Ok(Handle::new(
+            RegistrationLocation::Global(hotkey_key),
             registration_marker,
-            manager: self.inner.clone(),
-        })
+            self.inner.clone(),
+        ))
     }
 
     fn register_device_hotkey<F>(
@@ -373,11 +373,11 @@ impl HotkeyManager {
             .unwrap()
             .insert(id, registration);
 
-        Ok(Handle {
-            location: RegistrationLocation::Device(id),
+        Ok(Handle::new(
+            RegistrationLocation::Device(id),
             registration_marker,
-            manager: self.inner.clone(),
-        })
+            self.inner.clone(),
+        ))
     }
 
     /// Register a multi-step key sequence.
@@ -463,10 +463,7 @@ impl HotkeyManager {
             .unwrap()
             .insert(sequence_id, registration);
 
-        Ok(SequenceHandle {
-            id: sequence_id,
-            manager: self.inner.clone(),
-        })
+        Ok(SequenceHandle::new(sequence_id, self.inner.clone()))
     }
 
     /// Define a named mode with its bindings and options.
@@ -652,11 +649,11 @@ impl HotkeyManager {
             return Err(Error::ManagerStopped);
         }
 
-        Ok(Handle {
-            location: RegistrationLocation::Global(hotkey_key),
+        Ok(Handle::new(
+            RegistrationLocation::Global(hotkey_key),
             registration_marker,
-            manager: self.inner.clone(),
-        })
+            self.inner.clone(),
+        ))
     }
 
     fn replace_device_hotkey<F>(
@@ -708,11 +705,11 @@ impl HotkeyManager {
             id
         };
 
-        Handle {
-            location: RegistrationLocation::Device(id),
+        Handle::new(
+            RegistrationLocation::Device(id),
             registration_marker,
-            manager: self.inner.clone(),
-        }
+            self.inner.clone(),
+        )
     }
 
     /// Register a dual-function tap-hold key.
@@ -767,11 +764,11 @@ impl HotkeyManager {
             .unwrap()
             .insert(key, registration);
 
-        Ok(TapHoldHandle {
+        Ok(TapHoldHandle::new(
             key,
             registration_marker,
-            manager: self.inner.clone(),
-        })
+            self.inner.clone(),
+        ))
     }
 
     /// Returns `true` if a global hotkey with this key + modifier combination
@@ -1695,7 +1692,7 @@ mod tests {
 
         assert!(!manager.is_registered(Key::D, &[Modifier::Ctrl]));
 
-        manager.register(Key::D, &[Modifier::Ctrl], || {}).unwrap();
+        let _handle = manager.register(Key::D, &[Modifier::Ctrl], || {}).unwrap();
 
         assert!(manager.is_registered(Key::D, &[Modifier::Ctrl]));
     }
@@ -1783,10 +1780,10 @@ mod tests {
         let manager = manager_with_fake_backend();
         let calls = Arc::new(AtomicUsize::new(0));
 
-        manager.register(Key::E, &[Modifier::Shift], || {}).unwrap();
+        let _handle = manager.register(Key::E, &[Modifier::Shift], || {}).unwrap();
 
         let calls_clone = calls.clone();
-        manager
+        let _handle = manager
             .replace(Key::E, &[Modifier::Shift], move || {
                 calls_clone.fetch_add(1, Ordering::SeqCst);
             })
@@ -1807,9 +1804,9 @@ mod tests {
             register_calls: register_calls.clone(),
         }));
 
-        manager.register(Key::T, &[Modifier::Alt], || {}).unwrap();
+        let _handle = manager.register(Key::T, &[Modifier::Alt], || {}).unwrap();
 
-        manager.replace(Key::T, &[Modifier::Alt], || {}).unwrap();
+        let _handle = manager.replace(Key::T, &[Modifier::Alt], || {}).unwrap();
 
         assert_eq!(register_calls.load(Ordering::SeqCst), 1);
     }
@@ -1819,7 +1816,7 @@ mod tests {
         let register_calls = Arc::new(AtomicUsize::new(0));
         let manager = manager_with_backend(Arc::new(FailsSecondRegisterBackend { register_calls }));
 
-        manager.register(Key::U, &[Modifier::Alt], || {}).unwrap();
+        let _handle = manager.register(Key::U, &[Modifier::Alt], || {}).unwrap();
 
         let err = manager
             .register(Key::I, &[Modifier::Alt], || {})
@@ -1954,7 +1951,7 @@ mod tests {
         let stale_handle = manager.register(Key::T, &[Modifier::Alt], || {}).unwrap();
 
         let calls_clone = calls.clone();
-        manager
+        let _new_handle = manager
             .replace(Key::T, &[Modifier::Alt], move || {
                 calls_clone.fetch_add(1, Ordering::SeqCst);
             })
@@ -1986,7 +1983,7 @@ mod tests {
             .unwrap();
 
         let calls_clone = calls.clone();
-        manager
+        let _new_handle = manager
             .replace_with_options(
                 Key::Num4,
                 &[],
@@ -2100,7 +2097,7 @@ mod tests {
         allow_unregister_finish.store(true, Ordering::SeqCst);
 
         unregister_thread.join().unwrap().unwrap();
-        replace_thread.join().unwrap().unwrap();
+        let _handle = replace_thread.join().unwrap().unwrap();
 
         assert!(backend_registered.load(Ordering::SeqCst));
         assert!(manager.is_registered(Key::Y, &[Modifier::Ctrl]));
@@ -2273,6 +2270,126 @@ mod tests {
             .lock()
             .unwrap()
             .is_empty());
+    }
+
+    #[test]
+    fn handle_drop_unregisters_hotkey() {
+        let manager = manager_with_fake_backend();
+
+        {
+            let _handle = manager.register(Key::A, &[Modifier::Ctrl], || {}).unwrap();
+            assert!(manager.is_registered(Key::A, &[Modifier::Ctrl]));
+        }
+
+        assert!(!manager.is_registered(Key::A, &[Modifier::Ctrl]));
+    }
+
+    #[test]
+    fn handle_clone_keeps_hotkey_alive_until_last_drop() {
+        let manager = manager_with_fake_backend();
+
+        let handle = manager.register(Key::B, &[Modifier::Ctrl], || {}).unwrap();
+        let clone = handle.clone();
+
+        drop(handle);
+        assert!(manager.is_registered(Key::B, &[Modifier::Ctrl]));
+
+        drop(clone);
+        assert!(!manager.is_registered(Key::B, &[Modifier::Ctrl]));
+    }
+
+    #[test]
+    fn explicit_unregister_removes_even_with_clones() {
+        let manager = manager_with_fake_backend();
+
+        let handle = manager.register(Key::C, &[Modifier::Ctrl], || {}).unwrap();
+        let _clone = handle.clone();
+
+        handle.unregister().unwrap();
+        assert!(!manager.is_registered(Key::C, &[Modifier::Ctrl]));
+    }
+
+    #[test]
+    fn sequence_handle_drop_unregisters() {
+        let manager = manager_with_fake_backend();
+
+        {
+            let _handle = manager
+                .register_sequence(
+                    &HotkeySequence::new(vec![
+                        Hotkey::new(Key::K, vec![Modifier::Ctrl]),
+                        Hotkey::new(Key::C, vec![Modifier::Ctrl]),
+                    ])
+                    .unwrap(),
+                    SequenceOptions::new(),
+                    || {},
+                )
+                .unwrap();
+
+            assert!(!manager
+                .inner
+                .sequence_registrations
+                .lock()
+                .unwrap()
+                .is_empty());
+        }
+
+        assert!(manager
+            .inner
+            .sequence_registrations
+            .lock()
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn tap_hold_handle_drop_unregisters() {
+        let manager = manager_with_backend_and_grab(Arc::new(FakeBackend), true);
+
+        {
+            let _handle = manager
+                .register_tap_hold(
+                    Key::CapsLock,
+                    crate::tap_hold::TapAction::emit(Key::Escape),
+                    crate::tap_hold::HoldAction::modifier(Modifier::Ctrl),
+                    crate::tap_hold::TapHoldOptions::new(),
+                )
+                .unwrap();
+
+            assert!(manager
+                .inner
+                .tap_hold_registrations
+                .lock()
+                .unwrap()
+                .contains_key(&Key::CapsLock));
+        }
+
+        assert!(!manager
+            .inner
+            .tap_hold_registrations
+            .lock()
+            .unwrap()
+            .contains_key(&Key::CapsLock));
+    }
+
+    #[test]
+    fn device_handle_drop_unregisters() {
+        let manager = manager_with_fake_backend();
+
+        {
+            let _handle = manager
+                .register_with_options(
+                    Key::Num1,
+                    &[],
+                    HotkeyOptions::new().device(DeviceFilter::name_contains("StreamDeck")),
+                    || {},
+                )
+                .unwrap();
+
+            assert_eq!(manager.inner.device_registrations.lock().unwrap().len(), 1);
+        }
+
+        assert_eq!(manager.inner.device_registrations.lock().unwrap().len(), 0);
     }
 
     #[test]
@@ -2492,7 +2609,7 @@ mod tests {
         let manager = manager_with_fake_backend();
         let filter = DeviceFilter::name_contains("StreamDeck");
 
-        manager
+        let _handle = manager
             .register_with_options(
                 Key::Num1,
                 &[],
@@ -2513,7 +2630,7 @@ mod tests {
     fn device_specific_different_filter_no_conflict() {
         let manager = manager_with_fake_backend();
 
-        manager
+        let _handle1 = manager
             .register_with_options(
                 Key::Num1,
                 &[],
@@ -2522,7 +2639,7 @@ mod tests {
             )
             .unwrap();
 
-        manager
+        let _handle2 = manager
             .register_with_options(
                 Key::Num1,
                 &[],
@@ -2538,9 +2655,9 @@ mod tests {
     fn device_specific_and_global_same_key_no_conflict() {
         let manager = manager_with_fake_backend();
 
-        manager.register(Key::Num1, &[], || {}).unwrap();
+        let _handle1 = manager.register(Key::Num1, &[], || {}).unwrap();
 
-        manager
+        let _handle2 = manager
             .register_with_options(
                 Key::Num1,
                 &[],
@@ -2559,7 +2676,7 @@ mod tests {
         let filter = DeviceFilter::name_contains("StreamDeck");
         let count = Arc::new(AtomicUsize::new(0));
 
-        manager
+        let _handle = manager
             .register_with_options(
                 Key::Num1,
                 &[],
@@ -2569,7 +2686,7 @@ mod tests {
             .unwrap();
 
         let count_clone = count.clone();
-        manager
+        let _handle = manager
             .replace_with_options(
                 Key::Num1,
                 &[],
@@ -2690,7 +2807,7 @@ mod tests {
     fn tap_hold_rejects_duplicate_key() {
         let manager = manager_with_backend_and_grab(Arc::new(FakeBackend), true);
 
-        manager
+        let _handle = manager
             .register_tap_hold(
                 Key::CapsLock,
                 crate::tap_hold::TapAction::emit(Key::Escape),
@@ -2728,7 +2845,7 @@ mod tests {
         let stale_clone = stale_handle.clone();
         stale_handle.unregister().unwrap();
 
-        manager
+        let _new_handle = manager
             .register_tap_hold(
                 Key::CapsLock,
                 crate::tap_hold::TapAction::emit(Key::Tab),
@@ -2837,7 +2954,7 @@ mod tests {
             .sequence_registrations
             .lock()
             .unwrap()
-            .get(&sequence_handle.id)
+            .get(&sequence_handle.id())
             .unwrap()
             .callback
             .clone();
@@ -2870,7 +2987,7 @@ mod tests {
         assert_eq!(
             stream.try_next(),
             Some(HotkeyEvent::SequenceStep {
-                id: sequence_handle.id,
+                id: sequence_handle.id(),
                 step: 2,
                 total: 2,
             }),

--- a/src/manager/handles.rs
+++ b/src/manager/handles.rs
@@ -14,21 +14,77 @@ pub(crate) enum RegistrationLocation {
     Device(DeviceRegistrationId),
 }
 
+struct HandleInner {
+    location: RegistrationLocation,
+    registration_marker: Callback,
+    manager: Arc<HotkeyManagerInner>,
+}
+
+impl Drop for HandleInner {
+    fn drop(&mut self) {
+        match &self.location {
+            RegistrationLocation::Global(key) => {
+                let _ = self.manager.remove_hotkey(key, &self.registration_marker);
+            }
+            RegistrationLocation::Device(id) => {
+                self.manager
+                    .remove_device_hotkey(*id, &self.registration_marker);
+            }
+        }
+    }
+}
+
 /// Handle for a registered hotkey.
 ///
 /// The hotkey remains active as long as the handle (or any clone) exists.
-/// Call [`Handle::unregister`] to explicitly remove it, or simply drop the
-/// handle if you want the binding to live for the lifetime of the manager.
+/// When the last clone is dropped, the hotkey is automatically unregistered.
+///
+/// Call [`Handle::unregister`] to explicitly remove the registration
+/// immediately, regardless of how many clones exist.
 #[derive(Clone)]
 pub struct Handle {
-    pub(super) location: RegistrationLocation,
-    pub(super) registration_marker: Callback,
-    pub(super) manager: Arc<HotkeyManagerInner>,
+    inner: Arc<HandleInner>,
+}
+
+impl Handle {
+    pub(super) fn new(
+        location: RegistrationLocation,
+        registration_marker: Callback,
+        manager: Arc<HotkeyManagerInner>,
+    ) -> Self {
+        Self {
+            inner: Arc::new(HandleInner {
+                location,
+                registration_marker,
+                manager,
+            }),
+        }
+    }
+
+    /// Remove this hotkey registration immediately. Future key presses will
+    /// no longer trigger the callback.
+    ///
+    /// This unregisters even if other clones of this handle exist. Those
+    /// clones become inert — their eventual drop is a no-op.
+    pub fn unregister(self) -> Result<(), Error> {
+        match &self.inner.location {
+            RegistrationLocation::Global(key) => self
+                .inner
+                .manager
+                .remove_hotkey(key, &self.inner.registration_marker),
+            RegistrationLocation::Device(id) => {
+                self.inner
+                    .manager
+                    .remove_device_hotkey(*id, &self.inner.registration_marker);
+                Ok(())
+            }
+        }
+    }
 }
 
 impl std::fmt::Debug for Handle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.location {
+        match &self.inner.location {
             RegistrationLocation::Global(key) => f
                 .debug_struct("Handle")
                 .field("key", key)
@@ -41,71 +97,117 @@ impl std::fmt::Debug for Handle {
     }
 }
 
-impl Handle {
-    /// Remove this hotkey registration. Future key presses will no longer
-    /// trigger the callback.
-    pub fn unregister(self) -> Result<(), Error> {
-        match &self.location {
-            RegistrationLocation::Global(key) => {
-                self.manager.remove_hotkey(key, &self.registration_marker)
-            }
-            RegistrationLocation::Device(id) => {
-                self.manager
-                    .remove_device_hotkey(*id, &self.registration_marker);
-                Ok(())
-            }
-        }
+struct SequenceHandleInner {
+    id: SequenceId,
+    manager: Arc<HotkeyManagerInner>,
+}
+
+impl Drop for SequenceHandleInner {
+    fn drop(&mut self) {
+        self.manager.remove_sequence(self.id);
     }
 }
 
 /// Handle for a registered key sequence.
 ///
-/// See [`Handle`] for lifetime semantics.
+/// The sequence remains active as long as the handle (or any clone) exists.
+/// When the last clone is dropped, the sequence is automatically unregistered.
+///
+/// Call [`SequenceHandle::unregister`] to explicitly remove the registration
+/// immediately, regardless of how many clones exist.
 #[derive(Clone)]
 pub struct SequenceHandle {
-    pub(super) id: SequenceId,
-    pub(super) manager: Arc<HotkeyManagerInner>,
+    inner: Arc<SequenceHandleInner>,
+}
+
+impl SequenceHandle {
+    pub(super) fn new(id: SequenceId, manager: Arc<HotkeyManagerInner>) -> Self {
+        Self {
+            inner: Arc::new(SequenceHandleInner { id, manager }),
+        }
+    }
+
+    /// The unique ID for this sequence registration.
+    #[must_use]
+    pub fn id(&self) -> SequenceId {
+        self.inner.id
+    }
+
+    /// Remove this sequence registration immediately.
+    ///
+    /// This unregisters even if other clones of this handle exist. Those
+    /// clones become inert — their eventual drop is a no-op.
+    pub fn unregister(self) -> Result<(), Error> {
+        self.inner.manager.remove_sequence(self.inner.id);
+        Ok(())
+    }
 }
 
 impl std::fmt::Debug for SequenceHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SequenceHandle")
-            .field("id", &self.id)
+            .field("id", &self.inner.id)
             .finish_non_exhaustive()
     }
 }
 
-impl SequenceHandle {
-    /// Remove this sequence registration.
-    pub fn unregister(self) -> Result<(), Error> {
-        self.manager.remove_sequence(self.id);
-        Ok(())
+struct TapHoldHandleInner {
+    key: Key,
+    registration_marker: Arc<()>,
+    manager: Arc<HotkeyManagerInner>,
+}
+
+impl Drop for TapHoldHandleInner {
+    fn drop(&mut self) {
+        self.manager
+            .remove_tap_hold(self.key, &self.registration_marker);
     }
 }
 
 /// Handle for a registered tap-hold key binding.
 ///
-/// See [`Handle`] for lifetime semantics.
+/// The tap-hold binding remains active as long as the handle (or any clone)
+/// exists. When the last clone is dropped, the binding is automatically
+/// unregistered.
+///
+/// Call [`TapHoldHandle::unregister`] to explicitly remove the registration
+/// immediately, regardless of how many clones exist.
 #[derive(Clone)]
 pub struct TapHoldHandle {
-    pub(super) key: Key,
-    pub(super) registration_marker: Arc<()>,
-    pub(super) manager: Arc<HotkeyManagerInner>,
+    inner: Arc<TapHoldHandleInner>,
+}
+
+impl TapHoldHandle {
+    pub(super) fn new(
+        key: Key,
+        registration_marker: Arc<()>,
+        manager: Arc<HotkeyManagerInner>,
+    ) -> Self {
+        Self {
+            inner: Arc::new(TapHoldHandleInner {
+                key,
+                registration_marker,
+                manager,
+            }),
+        }
+    }
+
+    /// Remove this tap-hold registration immediately.
+    ///
+    /// This unregisters even if other clones of this handle exist. Those
+    /// clones become inert — their eventual drop is a no-op.
+    pub fn unregister(self) -> Result<(), Error> {
+        self.inner
+            .manager
+            .remove_tap_hold(self.inner.key, &self.inner.registration_marker);
+        Ok(())
+    }
 }
 
 impl std::fmt::Debug for TapHoldHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TapHoldHandle")
-            .field("key", &self.key)
+            .field("key", &self.inner.key)
             .finish_non_exhaustive()
-    }
-}
-
-impl TapHoldHandle {
-    /// Remove this tap-hold registration.
-    pub fn unregister(self) -> Result<(), Error> {
-        self.manager
-            .remove_tap_hold(self.key, &self.registration_marker);
-        Ok(())
     }
 }


### PR DESCRIPTION
All three handle types now automatically unregister their binding when the last clone is dropped, matching the documented semantics.

## Problem

`Handle`, `SequenceHandle`, and `TapHoldHandle` documented RAII behavior ("the hotkey remains active as long as the handle exists") but had no `Drop` impl — dropping a handle was a silent no-op, leaving the registration alive forever unless `.unregister()` was called explicitly.

## Solution

Wrap each handle's internals in `Arc<Inner>` where the `Inner` struct implements `Drop`:

| Handle type | Inner struct | Drop calls |
|---|---|---|
| `Handle` | `HandleInner` | `remove_hotkey` / `remove_device_hotkey` |
| `SequenceHandle` | `SequenceHandleInner` | `remove_sequence` |
| `TapHoldHandle` | `TapHoldHandleInner` | `remove_tap_hold` |

### Semantics

- **Clone** = `Arc::clone` (ref count bump) — binding stays alive while any clone exists
- **Last drop** = `Inner::drop` runs, unregisters the binding
- **Explicit `unregister(self)`** = immediate unregister regardless of clone count; remaining clones' eventual drops are no-ops (the underlying remove methods are already idempotent via `Arc::ptr_eq` marker checks)

### Other changes

- Added `SequenceHandle::id()` public accessor (field was previously `pub(super)`, now behind Arc)
- Fixed ~15 existing tests that discarded handles (now store in `_handle` bindings)
- Added 6 new tests validating RAII behavior for all handle types
- Updated `conflict_detection` example doc comment