### PR TITLE
Clean up code review findings

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -31,6 +31,7 @@ pub enum DeviceFilter {
 
 impl DeviceFilter {
     /// Create a filter that matches devices whose name contains the given pattern.
+    #[must_use]
     pub fn name_contains(pattern: impl Into<String>) -> Self {
         DeviceFilter::NameContains(pattern.into())
     }

--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -38,7 +38,9 @@ pub struct Hotkey {
 
 /// An ordered sequence of [`Hotkey`] steps, such as `Ctrl+K, Ctrl+C`.
 ///
-/// Sequences must contain at least two steps. Parse from a comma-separated
+/// Must contain at least one step. Note that
+/// [`HotkeyManager::register_sequence`](crate::HotkeyManager::register_sequence)
+/// additionally requires at least two steps. Parse from a comma-separated
 /// string or build programmatically:
 ///
 /// ```

--- a/src/mode/dispatch.rs
+++ b/src/mode/dispatch.rs
@@ -164,17 +164,11 @@ fn dispatch_mode_repeat(
     definitions: &HashMap<String, ModeDefinition>,
     active_presses: &mut HashMap<Key, ActiveHotkeyPress>,
 ) -> ModeEventDispatch {
-    let is_mode_press = active_presses
-        .get(&key)
-        .is_some_and(|active| matches!(active.origin, PressOrigin::Mode(_)));
-
-    if !is_mode_press {
+    let Some(active) = active_presses.get_mut(&key) else {
         return ModeEventDispatch::PassThrough;
-    }
-
-    let active = active_presses.get_mut(&key).unwrap();
+    };
     let PressOrigin::Mode(ref mode_name) = active.origin else {
-        unreachable!();
+        return ModeEventDispatch::PassThrough;
     };
 
     let Some(registration) = definitions


### PR DESCRIPTION
Three small improvements found during code review:

1. **Simplify `dispatch_mode_repeat` double lookup** (`src/mode/dispatch.rs`): The function did a `.get()` to check if the key was a mode press, then immediately did `.get_mut().unwrap()` followed by `let ... else { unreachable!() }` on the same condition it just checked. Replaced with a single `get_mut` + two `let ... else { return PassThrough }` pattern matches — no unwrap, no unreachable, no redundant HashMap lookup.

2. **Add missing `#[must_use]` on `DeviceFilter::name_contains()`** (`src/device.rs`): The `usb()` constructor had `#[must_use]` but `name_contains()` did not. Both are constructors returning `Self`.

3. **Fix misleading `HotkeySequence` struct doc** (`src/hotkey.rs`): The struct-level doc stated "Sequences must contain at least two steps" but `HotkeySequence::new()` only requires non-empty (≥1 step), and `FromStr` can produce single-step sequences. The two-step minimum is enforced at registration time by `HotkeyManager::register_sequence`. Updated the doc to accurately reflect this.