### PR TITLE
Reposition project as a keyboard shortcut engine

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,13 +1,11 @@
-# keybound: Redesign
+# kbd: Redesign
 
 This document captures the core ideas, domain model, and architectural
-direction for the keybound project. It's not a task list — it's the
-conceptual foundation that the task list should serve.
+direction for kbd. It's not a task list — it's the conceptual
+foundation that the task list should serve.
 
-**Naming**: The workspace is `keybound`. All crates use the `kbd-`
-prefix — short for both "keybound" (the project) and "keyboard" (the
-domain). The global hotkey facade is `kbd-global` (was `keybound` in
-the monolith era).
+**Naming**: The project is `kbd`. All crates use the `kbd-` prefix:
+`kbd-core`, `kbd-global`, `kbd-crossterm`, etc.
 
 See [ATTRIBUTION.md](ATTRIBUTION.md) for licensing constraints on
 reference projects. Some can be adapted (MIT), others are
@@ -15,7 +13,7 @@ inspiration-only (GPL).
 
 ## What is this library?
 
-keybound is a keyboard shortcut engine for Rust.
+kbd is a keyboard shortcut engine for Rust.
 
 The core (`kbd-core`) is platform-agnostic — it handles key types,
 modifier tracking, binding matching, layer stacks, and sequence
@@ -215,12 +213,11 @@ The `kbd-global` facade operates at two levels:
    shortcut activation signals — no grab, no remapping, no raw key
    state.
 
-### What keybound is not
+### What kbd is not
 
 **Not a text input library.** Text input (IME composition, dead keys,
-Unicode output) is fundamentally different from key binding. The
-keybound project deals in key identities and modifier combinations,
-not composed text.
+Unicode output) is fundamentally different from key binding. kbd deals
+in key identities and modifier combinations, not composed text.
 
 **Not a terminal or GUI framework.** The library doesn't decode terminal
 escape sequences (that's crossterm) or manage widget focus (that's your

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,8 +1,8 @@
-# keybound: Implementation Plan
+# kbd: Implementation Plan
 
-Ground-up rebuild based on [DESIGN.md](DESIGN.md). The workspace is
-`keybound`; all crates use the `kbd-` prefix. The global hotkey facade
-is `kbd-global`.
+Ground-up rebuild based on [DESIGN.md](DESIGN.md). The project is
+`kbd`; all crates use the `kbd-` prefix: `kbd-core`, `kbd-global`,
+`kbd-crossterm`, etc.
 
 Prior implementation archived in `archive/v0/` and tagged `v0-archive` in git.
 Reference implementation (keyd) in `reference/keyd/`.
@@ -247,7 +247,7 @@ only matters once a layer stack exists.
 
 ## Phase 3.5: Workspace split and core extraction
 
-**Goal**: Split the keybound project into a multi-crate workspace. Each crate
+**Goal**: Split kbd into a multi-crate workspace. Each crate
 boundary is a dependency boundary — consumers pull in only what they
 need.
 
@@ -255,7 +255,7 @@ Every project we studied — Zed, COSMIC, Niri, every tiling WM — builds
 the same inner engine: key types, modifier tracking, layer/context
 stack, binding matching, sequence resolution. The only difference
 between global and in-app is where events come from and what "context"
-means. This phase recognizes that the project already has that engine and
+means. This phase recognizes that kbd already has that engine and
 makes it independently usable.
 
 This happens before Phase 4 because Phase 4 adds many features
@@ -267,7 +267,7 @@ pulling heavy deps into a monolith.
 ### Crate layout
 
 ```
-keybound/                         workspace root
+kbd/                              workspace root
 ├── crates/
 │   ├── kbd-core/                 Pure types + matcher + layers
 │   ├── kbd-crossterm/            crossterm key event conversions


### PR DESCRIPTION
## Summary

Repositions keybound from "a Linux global hotkey library" to "a keyboard shortcut engine for Rust, with a Linux global hotkey backend."

This is a doc-only PR — no code changes. It captures strategic decisions about the library's identity, key type foundation, and framework integration strategy before Phase 4 work begins.

## What changed

### DESIGN.md

- **"What is this library?"** — rewrites the opening to lead with use cases: TUI apps with modal keybindings, GUI apps with configurable shortcuts, compositors/editors, global hotkeys, key remappers, sandboxed apps
- **"Who should use what"** — expanded table with TUI (crossterm), winit/iced (native), egui rows
- **Crate split** — adds `kbd-crossterm` (TUI bridge) and `kbd-egui` (egui bridge) alongside existing crates
- **"Where kbd-core fits"** — new section showing kbd-core as a platform-agnostic matcher fed by any event source, separate from the Linux backend story
- **"Key identity"** — replaces the old "physical vs logical" framing with an honest treatment: Key semantics depend on the event source (physical from evdev, logical from crossterm), and kbd-core doesn't distinguish
- **`keyboard-types` adoption** — stated as decided (newtype over `Code`), not "open question"
- **"What keybound is not"** — tightened; references bridge crates instead of dismissing TUI/GUI use

### PLAN.md

- **§3.11** — replaces "Windowing library conversions" with "Adopt `keyboard-types` as the core key type" (13 checklist items for the newtype migration)
- **§3.12** — new "Framework integration crates" section with `kbd-crossterm` (5 items) and `kbd-egui` (4 items) checklists
- **Crate layout, deps tables, consumer matrix** — all updated for new crates and keyboard-types as required dep
- **Phase 7** — reframed as "Cross-platform backends" since `kbd-core` is already cross-platform
- **Implementation summary** — updated item counts and narrative

## Why now

This decision should be made before Phase 4 (sequences, serde, XKB, etc.) since those features build heavily on the key type. The keyboard-types adoption in §3.11 is the prerequisite for everything that follows.