### PR TITLE
refactor(kbd-egui): Prepare crate for v0.1.0 publish

### DIFF
--- a/crates/kbd-egui/README.md
+++ b/crates/kbd-egui/README.md
@@ -15,16 +15,16 @@ kbd-egui = "0.1"
 
 ## Extension traits
 
-- **`EguiKeyExt`** — converts an `egui::Key` to a `kbd::Key`
+- **`EguiKeyExt`** — converts an `egui::Key` to a `kbd::key::Key`
 - **`EguiModifiersExt`** — converts `egui::Modifiers` to a `Vec<Modifier>`
-- **`EguiEventExt`** — converts a full `egui::Event` keyboard event to a `kbd::Hotkey`
+- **`EguiEventExt`** — converts a full `egui::Event` keyboard event to a `kbd::hotkey::Hotkey`
 
 ## Usage
 
 ```rust
 use egui::{Key as EguiKey, Modifiers};
-use kbd::key::{Hotkey, Key, Modifier};
-use kbd_egui::{EguiKeyExt, EguiModifiersExt, EguiEventExt};
+use kbd::prelude::*;
+use kbd_egui::{EguiEventExt, EguiKeyExt, EguiModifiersExt};
 
 let key = EguiKey::A.to_key();
 assert_eq!(key, Some(Key::A));

--- a/crates/kbd-egui/src/lib.rs
+++ b/crates/kbd-egui/src/lib.rs
@@ -42,9 +42,8 @@
 //!
 //! ```
 //! use egui::{Key as EguiKey, Modifiers};
-//! use kbd::hotkey::{Hotkey, Modifier};
-//! use kbd::key::Key;
-//! use kbd_egui::{EguiKeyExt, EguiModifiersExt};
+//! use kbd::prelude::*;
+//! use kbd_egui::{EguiEventExt, EguiKeyExt, EguiModifiersExt};
 //!
 //! // Single key conversion
 //! let key = EguiKey::A.to_key();
@@ -62,7 +61,6 @@
 //!     repeat: false,
 //!     modifiers: Modifiers::CTRL,
 //! };
-//! use kbd_egui::EguiEventExt;
 //! let hotkey = event.to_hotkey();
 //! assert_eq!(hotkey, Some(Hotkey::new(Key::C).modifier(Modifier::Ctrl)));
 //! ```
@@ -73,20 +71,29 @@ use kbd::hotkey::Hotkey;
 use kbd::hotkey::Modifier;
 use kbd::key::Key;
 
+mod private {
+    pub trait Sealed {}
+    impl Sealed for egui::Key {}
+    impl Sealed for egui::Modifiers {}
+    impl Sealed for egui::Event {}
+}
+
 /// Convert an [`egui::Key`] to a `kbd` [`Key`].
 ///
 /// Returns `None` for egui keys that represent logical/shifted characters
 /// without a single physical key equivalent (e.g., `Colon`, `Pipe`,
 /// `Plus`, `Questionmark`). Most egui keys map directly to a physical
 /// key position.
-pub trait EguiKeyExt {
+///
+/// This trait is sealed and cannot be implemented outside this crate.
+pub trait EguiKeyExt: private::Sealed {
     /// Convert this egui key to a `kbd` [`Key`], or `None` if unmappable.
     ///
     /// # Examples
     ///
     /// ```
     /// use egui::Key as EguiKey;
-    /// use kbd::key::Key;
+    /// use kbd::prelude::*;
     /// use kbd_egui::EguiKeyExt;
     ///
     /// assert_eq!(EguiKey::A.to_key(), Some(Key::A));
@@ -94,6 +101,7 @@ pub trait EguiKeyExt {
     /// // Shifted characters have no physical key equivalent
     /// assert_eq!(EguiKey::Colon.to_key(), None);
     /// ```
+    #[must_use]
     fn to_key(&self) -> Option<Key>;
 }
 
@@ -242,14 +250,16 @@ impl EguiKeyExt for EguiKey {
 /// - `shift` → `Modifier::Shift`
 /// - `alt` → `Modifier::Alt`
 /// - `mac_cmd` → `Modifier::Super`
-pub trait EguiModifiersExt {
+///
+/// This trait is sealed and cannot be implemented outside this crate.
+pub trait EguiModifiersExt: private::Sealed {
     /// Convert these egui modifiers to a `Vec<Modifier>`.
     ///
     /// # Examples
     ///
     /// ```
     /// use egui::Modifiers;
-    /// use kbd::hotkey::Modifier;
+    /// use kbd::prelude::*;
     /// use kbd_egui::EguiModifiersExt;
     ///
     /// let mods = Modifiers {
@@ -258,25 +268,22 @@ pub trait EguiModifiersExt {
     /// };
     /// assert_eq!(mods.to_modifiers(), vec![Modifier::Ctrl, Modifier::Shift]);
     /// ```
+    #[must_use]
     fn to_modifiers(&self) -> Vec<Modifier>;
 }
 
 impl EguiModifiersExt for Modifiers {
     fn to_modifiers(&self) -> Vec<Modifier> {
-        let mut modifiers = Vec::new();
-        if self.ctrl {
-            modifiers.push(Modifier::Ctrl);
-        }
-        if self.shift {
-            modifiers.push(Modifier::Shift);
-        }
-        if self.alt {
-            modifiers.push(Modifier::Alt);
-        }
-        if self.mac_cmd {
-            modifiers.push(Modifier::Super);
-        }
-        modifiers
+        [
+            (self.ctrl, Modifier::Ctrl),
+            (self.shift, Modifier::Shift),
+            (self.alt, Modifier::Alt),
+            (self.mac_cmd, Modifier::Super),
+        ]
+        .into_iter()
+        .filter(|(active, _)| *active)
+        .map(|(_, m)| m)
+        .collect()
     }
 }
 
@@ -287,15 +294,16 @@ impl EguiModifiersExt for Modifiers {
 ///
 /// Only `Event::Key { .. }` variants produce a hotkey. All other event
 /// variants return `None`.
-pub trait EguiEventExt {
+///
+/// This trait is sealed and cannot be implemented outside this crate.
+pub trait EguiEventExt: private::Sealed {
     /// Convert this event to a [`Hotkey`], or `None` if not a keyboard event.
     ///
     /// # Examples
     ///
     /// ```
     /// use egui::{Key as EguiKey, Modifiers};
-    /// use kbd::hotkey::{Hotkey, Modifier};
-    /// use kbd::key::Key;
+    /// use kbd::prelude::*;
     /// use kbd_egui::EguiEventExt;
     ///
     /// let event = egui::Event::Key {
@@ -310,6 +318,7 @@ pub trait EguiEventExt {
     ///     Some(Hotkey::new(Key::S).modifier(Modifier::Ctrl)),
     /// );
     /// ```
+    #[must_use]
     fn to_hotkey(&self) -> Option<Hotkey>;
 }
 
@@ -402,6 +411,11 @@ mod tests {
         assert_eq!(EguiKey::CloseBracket.to_key(), Some(Key::BRACKET_RIGHT));
         assert_eq!(EguiKey::Equals.to_key(), Some(Key::EQUAL));
         assert_eq!(EguiKey::Quote.to_key(), Some(Key::QUOTE));
+    }
+
+    #[test]
+    fn browser_back_key() {
+        assert_eq!(EguiKey::BrowserBack.to_key(), Some(Key::BROWSER_BACK));
     }
 
     #[test]

--- a/crates/kbd-egui/tests/public_api.rs
+++ b/crates/kbd-egui/tests/public_api.rs
@@ -1,0 +1,214 @@
+//! Integration tests that exercise kbd-egui's public API as an outside consumer would.
+//!
+//! These complement the unit tests in lib.rs by verifying that:
+//! - Import paths work as documented
+//! - Converted types compose correctly with kbd's dispatcher
+//! - Real workflows (convert event → register → process → match) hold together
+
+use egui::Key as EguiKey;
+use egui::Modifiers;
+use kbd::action::Action;
+use kbd::dispatcher::Dispatcher;
+use kbd::dispatcher::MatchResult;
+use kbd::hotkey::Hotkey;
+use kbd::hotkey::Modifier;
+use kbd::key::Key;
+use kbd::key_state::KeyTransition;
+use kbd_egui::EguiEventExt;
+use kbd_egui::EguiKeyExt;
+use kbd_egui::EguiModifiersExt;
+
+fn key_event(key: EguiKey, modifiers: Modifiers) -> egui::Event {
+    egui::Event::Key {
+        key,
+        physical_key: None,
+        pressed: true,
+        repeat: false,
+        modifiers,
+    }
+}
+
+#[test]
+fn convert_and_dispatch_simple_hotkey() {
+    let mut dispatcher = Dispatcher::new();
+    dispatcher
+        .register(
+            Hotkey::new(Key::S).modifier(Modifier::Ctrl),
+            Action::Suppress,
+        )
+        .unwrap();
+
+    let event = key_event(EguiKey::S, Modifiers::CTRL);
+    let hotkey = event.to_hotkey().unwrap();
+    let result = dispatcher.process(&hotkey, KeyTransition::Press);
+    assert!(matches!(result, MatchResult::Matched { .. }));
+}
+
+#[test]
+fn convert_and_dispatch_multi_modifier_hotkey() {
+    let mut dispatcher = Dispatcher::new();
+    dispatcher
+        .register(
+            Hotkey::new(Key::A)
+                .modifier(Modifier::Ctrl)
+                .modifier(Modifier::Shift),
+            Action::Suppress,
+        )
+        .unwrap();
+
+    let mods = Modifiers {
+        alt: false,
+        ctrl: true,
+        shift: true,
+        mac_cmd: false,
+        command: false,
+    };
+    let event = key_event(EguiKey::A, mods);
+    let hotkey = event.to_hotkey().unwrap();
+    let result = dispatcher.process(&hotkey, KeyTransition::Press);
+    assert!(matches!(result, MatchResult::Matched { .. }));
+}
+
+#[test]
+fn unregistered_hotkey_does_not_match() {
+    let mut dispatcher = Dispatcher::new();
+    dispatcher
+        .register(
+            Hotkey::new(Key::S).modifier(Modifier::Ctrl),
+            Action::Suppress,
+        )
+        .unwrap();
+
+    let event = key_event(EguiKey::Q, Modifiers::CTRL);
+    let hotkey = event.to_hotkey().unwrap();
+    let result = dispatcher.process(&hotkey, KeyTransition::Press);
+    assert!(matches!(result, MatchResult::NoMatch));
+}
+
+#[test]
+fn unmappable_key_event_returns_none() {
+    let event = key_event(EguiKey::Colon, Modifiers::NONE);
+    assert!(event.to_hotkey().is_none());
+}
+
+#[test]
+fn non_key_event_returns_none() {
+    let event = egui::Event::PointerMoved(egui::pos2(10.0, 20.0));
+    assert!(event.to_hotkey().is_none());
+}
+
+#[test]
+fn converted_hotkey_equals_manually_built() {
+    let event = key_event(
+        EguiKey::C,
+        Modifiers {
+            alt: true,
+            ctrl: true,
+            shift: false,
+            mac_cmd: false,
+            command: false,
+        },
+    );
+    let from_event = event.to_hotkey().unwrap();
+    let manual = Hotkey::new(Key::C)
+        .modifier(Modifier::Ctrl)
+        .modifier(Modifier::Alt);
+    assert_eq!(from_event, manual);
+}
+
+#[test]
+fn trait_methods_are_independently_composable() {
+    let key = EguiKey::X.to_key().unwrap();
+    let mods = Modifiers {
+        alt: false,
+        ctrl: true,
+        shift: true,
+        mac_cmd: false,
+        command: false,
+    }
+    .to_modifiers();
+    let hotkey = Hotkey::with_modifiers(key, mods);
+
+    let expected = Hotkey::new(Key::X)
+        .modifier(Modifier::Ctrl)
+        .modifier(Modifier::Shift);
+    assert_eq!(hotkey, expected);
+}
+
+#[test]
+fn function_key_with_modifiers_roundtrip() {
+    let mut dispatcher = Dispatcher::new();
+    dispatcher
+        .register(
+            Hotkey::new(Key::F5)
+                .modifier(Modifier::Ctrl)
+                .modifier(Modifier::Shift),
+            Action::Suppress,
+        )
+        .unwrap();
+
+    let mods = Modifiers {
+        alt: false,
+        ctrl: true,
+        shift: true,
+        mac_cmd: false,
+        command: false,
+    };
+    let event = key_event(EguiKey::F5, mods);
+    let hotkey = event.to_hotkey().unwrap();
+    let result = dispatcher.process(&hotkey, KeyTransition::Press);
+    assert!(matches!(result, MatchResult::Matched { .. }));
+}
+
+#[test]
+fn string_parsed_and_converted_hotkeys_match() {
+    let parsed: Hotkey = "Ctrl+Shift+A".parse().unwrap();
+
+    let mods = Modifiers {
+        alt: false,
+        ctrl: true,
+        shift: true,
+        mac_cmd: false,
+        command: false,
+    };
+    let event = key_event(EguiKey::A, mods);
+    let converted = event.to_hotkey().unwrap();
+
+    assert_eq!(parsed, converted);
+}
+
+#[test]
+fn mac_cmd_maps_to_super_in_dispatch() {
+    let mut dispatcher = Dispatcher::new();
+    dispatcher
+        .register(
+            Hotkey::new(Key::S).modifier(Modifier::Super),
+            Action::Suppress,
+        )
+        .unwrap();
+
+    let mods = Modifiers {
+        alt: false,
+        ctrl: false,
+        shift: false,
+        mac_cmd: true,
+        command: true,
+    };
+    let event = key_event(EguiKey::S, mods);
+    let hotkey = event.to_hotkey().unwrap();
+    let result = dispatcher.process(&hotkey, KeyTransition::Press);
+    assert!(matches!(result, MatchResult::Matched { .. }));
+}
+
+#[test]
+fn browser_back_converts_and_dispatches() {
+    let mut dispatcher = Dispatcher::new();
+    dispatcher
+        .register(Hotkey::new(Key::BROWSER_BACK), Action::Suppress)
+        .unwrap();
+
+    let event = key_event(EguiKey::BrowserBack, Modifiers::NONE);
+    let hotkey = event.to_hotkey().unwrap();
+    let result = dispatcher.process(&hotkey, KeyTransition::Press);
+    assert!(matches!(result, MatchResult::Matched { .. }));
+}


### PR DESCRIPTION
## Changes

- **Seal all extension traits** (`EguiKeyExt`, `EguiModifiersExt`, `EguiEventExt`) with a private `Sealed` supertrait to prevent external implementation
- **Add `#[must_use]`** to all trait methods
- **Refactor `to_modifiers()`** to declarative iterator/collect pattern
- **Add integration tests** (`tests/public_api.rs`) covering:
  - Convert-and-dispatch workflows with the Dispatcher
  - Multi-modifier hotkeys
  - Unregistered hotkey non-matching
  - Unmappable key and non-key event handling
  - Trait composability (independent use of key/modifier traits)
  - String-parsed vs converted hotkey equality
  - `mac_cmd` → `Super` modifier dispatch
  - `BrowserBack` key conversion and dispatch
- **Add unit test** for `BrowserBack` key mapping
- **Fix README** import paths (`kbd::key::{Hotkey,Key,Modifier}` → split paths)

Follows the same patterns established in #77 (kbd) and #79 (kbd-crossterm).