### PR TITLE
refactor(kbd-evdev): Prepare crate for v0.1.0 publish

### DIFF
--- a/crates/kbd-evdev/README.md
+++ b/crates/kbd-evdev/README.md
@@ -36,7 +36,7 @@ kbd-evdev = "0.1"
 
 ```rust
 use evdev::KeyCode;
-use kbd::key::Key;
+use kbd::prelude::*;
 use kbd_evdev::{EvdevKeyCodeExt, KbdKeyExt};
 
 // evdev → kbd

--- a/crates/kbd-evdev/examples/evdev.rs
+++ b/crates/kbd-evdev/examples/evdev.rs
@@ -8,12 +8,7 @@
 //! cargo run -p kbd-evdev --example evdev
 //! ```
 
-use kbd::action::Action;
-use kbd::dispatcher::Dispatcher;
-use kbd::dispatcher::MatchResult;
-use kbd::hotkey::Hotkey;
-use kbd::key::Key;
-use kbd::key_state::KeyTransition;
+use kbd::prelude::*;
 use kbd_evdev::devices::DeviceGrabMode;
 use kbd_evdev::devices::DeviceManager;
 

--- a/crates/kbd-evdev/src/convert.rs
+++ b/crates/kbd-evdev/src/convert.rs
@@ -8,7 +8,7 @@
 //!
 //! ```rust
 //! use evdev::KeyCode;
-//! use kbd::key::Key;
+//! use kbd::prelude::*;
 //! use kbd_evdev::EvdevKeyCodeExt;
 //!
 //! let key: Key = KeyCode::KEY_A.to_key();
@@ -18,11 +18,19 @@
 use evdev::KeyCode;
 use kbd::key::Key;
 
+mod private {
+    pub trait Sealed {}
+    impl Sealed for evdev::KeyCode {}
+    impl Sealed for kbd::key::Key {}
+}
+
 /// Extension trait on [`evdev::KeyCode`] for converting to [`kbd::key::Key`].
 ///
 /// Returns [`Key::UNIDENTIFIED`] for key codes that have no `kbd` mapping
 /// (e.g., `KEY_PROG2`, `KEY_COFFEE`).
-pub trait EvdevKeyCodeExt {
+///
+/// This trait is sealed and cannot be implemented outside this crate.
+pub trait EvdevKeyCodeExt: private::Sealed {
     /// Convert this evdev key code to a [`Key`].
     ///
     /// Returns [`Key::UNIDENTIFIED`] for key codes that don't have a mapping.
@@ -31,7 +39,7 @@ pub trait EvdevKeyCodeExt {
     ///
     /// ```
     /// use evdev::KeyCode;
-    /// use kbd::key::Key;
+    /// use kbd::prelude::*;
     /// use kbd_evdev::EvdevKeyCodeExt;
     ///
     /// assert_eq!(KeyCode::KEY_A.to_key(), Key::A);
@@ -40,6 +48,7 @@ pub trait EvdevKeyCodeExt {
     /// // Unmapped codes return UNIDENTIFIED
     /// assert_eq!(KeyCode::KEY_PROG2.to_key(), Key::UNIDENTIFIED);
     /// ```
+    #[must_use]
     fn to_key(self) -> Key;
 }
 
@@ -47,7 +56,9 @@ pub trait EvdevKeyCodeExt {
 ///
 /// [`Key::UNIDENTIFIED`] and any key without a known evdev equivalent maps
 /// to `KeyCode::KEY_UNKNOWN`.
-pub trait KbdKeyExt {
+///
+/// This trait is sealed and cannot be implemented outside this crate.
+pub trait KbdKeyExt: private::Sealed {
     /// Convert this key to an evdev [`KeyCode`].
     ///
     /// [`Key::UNIDENTIFIED`] maps to `KeyCode::KEY_UNKNOWN`.
@@ -56,7 +67,7 @@ pub trait KbdKeyExt {
     ///
     /// ```
     /// use evdev::KeyCode;
-    /// use kbd::key::Key;
+    /// use kbd::prelude::*;
     /// use kbd_evdev::KbdKeyExt;
     ///
     /// assert_eq!(Key::A.to_key_code(), KeyCode::KEY_A);
@@ -65,6 +76,7 @@ pub trait KbdKeyExt {
     /// // UNIDENTIFIED maps to KEY_UNKNOWN
     /// assert_eq!(Key::UNIDENTIFIED.to_key_code(), KeyCode::KEY_UNKNOWN);
     /// ```
+    #[must_use]
     fn to_key_code(self) -> KeyCode;
 }
 
@@ -627,6 +639,166 @@ mod tests {
             Key::META_RIGHT,
         ];
         for key in modifiers {
+            let code = key.to_key_code();
+            let parsed = code.to_key();
+            assert_eq!(parsed, key, "round-trip failed for {key:?}");
+        }
+    }
+
+    #[test]
+    fn all_digits_round_trip() {
+        for key in [
+            Key::DIGIT0,
+            Key::DIGIT1,
+            Key::DIGIT2,
+            Key::DIGIT3,
+            Key::DIGIT4,
+            Key::DIGIT5,
+            Key::DIGIT6,
+            Key::DIGIT7,
+            Key::DIGIT8,
+            Key::DIGIT9,
+        ] {
+            let code = key.to_key_code();
+            let parsed = code.to_key();
+            assert_eq!(parsed, key, "round-trip failed for {key:?}");
+        }
+    }
+
+    #[test]
+    fn all_function_keys_round_trip() {
+        for key in [
+            Key::F1,
+            Key::F2,
+            Key::F3,
+            Key::F4,
+            Key::F5,
+            Key::F6,
+            Key::F7,
+            Key::F8,
+            Key::F9,
+            Key::F10,
+            Key::F11,
+            Key::F12,
+            Key::F13,
+            Key::F14,
+            Key::F15,
+            Key::F16,
+            Key::F17,
+            Key::F18,
+            Key::F19,
+            Key::F20,
+            Key::F21,
+            Key::F22,
+            Key::F23,
+            Key::F24,
+        ] {
+            let code = key.to_key_code();
+            let parsed = code.to_key();
+            assert_eq!(parsed, key, "round-trip failed for {key:?}");
+        }
+    }
+
+    #[test]
+    fn all_numpad_keys_round_trip() {
+        for key in [
+            Key::NUMPAD0,
+            Key::NUMPAD1,
+            Key::NUMPAD2,
+            Key::NUMPAD3,
+            Key::NUMPAD4,
+            Key::NUMPAD5,
+            Key::NUMPAD6,
+            Key::NUMPAD7,
+            Key::NUMPAD8,
+            Key::NUMPAD9,
+            Key::NUMPAD_DECIMAL,
+            Key::NUMPAD_ADD,
+            Key::NUMPAD_SUBTRACT,
+            Key::NUMPAD_MULTIPLY,
+            Key::NUMPAD_DIVIDE,
+            Key::NUMPAD_ENTER,
+            Key::NUMPAD_EQUAL,
+            Key::NUMPAD_COMMA,
+            Key::NUMPAD_PAREN_LEFT,
+            Key::NUMPAD_PAREN_RIGHT,
+        ] {
+            let code = key.to_key_code();
+            let parsed = code.to_key();
+            assert_eq!(parsed, key, "round-trip failed for {key:?}");
+        }
+    }
+
+    #[test]
+    fn punctuation_keys_round_trip() {
+        for key in [
+            Key::MINUS,
+            Key::EQUAL,
+            Key::BRACKET_LEFT,
+            Key::BRACKET_RIGHT,
+            Key::BACKSLASH,
+            Key::SEMICOLON,
+            Key::QUOTE,
+            Key::BACKQUOTE,
+            Key::COMMA,
+            Key::PERIOD,
+            Key::SLASH,
+        ] {
+            let code = key.to_key_code();
+            let parsed = code.to_key();
+            assert_eq!(parsed, key, "round-trip failed for {key:?}");
+        }
+    }
+
+    #[test]
+    fn navigation_keys_round_trip() {
+        for key in [
+            Key::ARROW_UP,
+            Key::ARROW_DOWN,
+            Key::ARROW_LEFT,
+            Key::ARROW_RIGHT,
+            Key::HOME,
+            Key::END,
+            Key::PAGE_UP,
+            Key::PAGE_DOWN,
+            Key::INSERT,
+            Key::DELETE,
+        ] {
+            let code = key.to_key_code();
+            let parsed = code.to_key();
+            assert_eq!(parsed, key, "round-trip failed for {key:?}");
+        }
+    }
+
+    #[test]
+    fn multiple_unmapped_keycodes_return_unidentified() {
+        for code in [
+            KeyCode::KEY_PROG2,
+            KeyCode::KEY_COFFEE,
+            KeyCode::KEY_DASHBOARD,
+        ] {
+            assert_eq!(
+                code.to_key(),
+                Key::UNIDENTIFIED,
+                "expected UNIDENTIFIED for {code:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn cjk_keys_round_trip() {
+        for key in [
+            Key::CONVERT,
+            Key::NON_CONVERT,
+            Key::KANA_MODE,
+            Key::HIRAGANA,
+            Key::KATAKANA,
+            Key::LANG1,
+            Key::LANG2,
+            Key::INTL_BACKSLASH,
+            Key::INTL_RO,
+            Key::INTL_YEN,
+        ] {
             let code = key.to_key_code();
             let parsed = code.to_key();
             assert_eq!(parsed, key, "round-trip failed for {key:?}");

--- a/crates/kbd-evdev/src/forwarder.rs
+++ b/crates/kbd-evdev/src/forwarder.rs
@@ -1,9 +1,7 @@
 //! uinput virtual device for event forwarding and emission.
 //!
 //! In grab mode, unmatched key events are re-emitted through a virtual
-//! device so they reach applications normally. Also used for `Action::EmitHotkey`
-//! to produce synthetic key events.
-//!
+//! device so they reach applications normally.
 //!
 //! Note: keyd creates two virtual devices (keyboard + pointer). For now
 //! we only need one (keyboard).

--- a/crates/kbd-evdev/src/lib.rs
+++ b/crates/kbd-evdev/src/lib.rs
@@ -70,7 +70,7 @@ pub mod error;
 /// Virtual uinput device for forwarding and emitting key events.
 pub mod forwarder;
 
-/// Convert a [`kbd::key::Key`] to an [`evdev::KeyCode`].
-pub use crate::convert::EvdevKeyCodeExt;
 /// Convert an [`evdev::KeyCode`] to a [`kbd::key::Key`].
+pub use crate::convert::EvdevKeyCodeExt;
+/// Convert a [`kbd::key::Key`] to an [`evdev::KeyCode`].
 pub use crate::convert::KbdKeyExt;

--- a/crates/kbd-evdev/tests/public_api.rs
+++ b/crates/kbd-evdev/tests/public_api.rs
@@ -1,0 +1,202 @@
+//! Integration tests that exercise kbd-evdev's public API as an outside consumer would.
+//!
+//! These complement the unit tests in the source modules by verifying that:
+//! - Import paths work as documented
+//! - Converted types compose correctly with kbd's dispatcher
+//! - Key conversion round-trips hold for real workflows
+//!
+//! Note: tests that require `/dev/input/` or `/dev/uinput` are not included
+//! here because they need hardware access and root/group permissions.
+
+use evdev::KeyCode;
+use kbd::prelude::*;
+use kbd_evdev::EvdevKeyCodeExt;
+use kbd_evdev::KbdKeyExt;
+
+#[test]
+fn convert_and_dispatch_simple_hotkey() {
+    let mut dispatcher = Dispatcher::new();
+    dispatcher
+        .register(
+            Hotkey::new(Key::A).modifier(Modifier::Ctrl),
+            Action::Suppress,
+        )
+        .unwrap();
+
+    let key = KeyCode::KEY_A.to_key();
+    let hotkey = Hotkey::new(key).modifier(Modifier::Ctrl);
+    let result = dispatcher.process(&hotkey, KeyTransition::Press);
+    assert!(matches!(result, MatchResult::Matched { .. }));
+}
+
+#[test]
+fn convert_and_dispatch_multi_modifier_hotkey() {
+    let mut dispatcher = Dispatcher::new();
+    dispatcher
+        .register(
+            Hotkey::new(Key::S)
+                .modifier(Modifier::Ctrl)
+                .modifier(Modifier::Shift),
+            Action::Suppress,
+        )
+        .unwrap();
+
+    let key = KeyCode::KEY_S.to_key();
+    let hotkey = Hotkey::new(key)
+        .modifier(Modifier::Ctrl)
+        .modifier(Modifier::Shift);
+    let result = dispatcher.process(&hotkey, KeyTransition::Press);
+    assert!(matches!(result, MatchResult::Matched { .. }));
+}
+
+#[test]
+fn unregistered_hotkey_does_not_match() {
+    let mut dispatcher = Dispatcher::new();
+    dispatcher
+        .register(
+            Hotkey::new(Key::S).modifier(Modifier::Ctrl),
+            Action::Suppress,
+        )
+        .unwrap();
+
+    let key = KeyCode::KEY_Q.to_key();
+    let hotkey = Hotkey::new(key).modifier(Modifier::Ctrl);
+    let result = dispatcher.process(&hotkey, KeyTransition::Press);
+    assert!(matches!(result, MatchResult::NoMatch));
+}
+
+#[test]
+fn unmapped_keycode_produces_unidentified() {
+    let key = KeyCode::KEY_PROG2.to_key();
+    assert_eq!(key, Key::UNIDENTIFIED);
+}
+
+#[test]
+fn unidentified_key_maps_to_key_unknown() {
+    let code = Key::UNIDENTIFIED.to_key_code();
+    assert_eq!(code, KeyCode::KEY_UNKNOWN);
+}
+
+#[test]
+fn converted_hotkey_equals_manually_built() {
+    let key = KeyCode::KEY_C.to_key();
+    let from_evdev = Hotkey::new(key)
+        .modifier(Modifier::Ctrl)
+        .modifier(Modifier::Alt);
+    let manual = Hotkey::new(Key::C)
+        .modifier(Modifier::Ctrl)
+        .modifier(Modifier::Alt);
+    assert_eq!(from_evdev, manual);
+}
+
+#[test]
+fn evdev_to_kbd_to_evdev_round_trip() {
+    let codes = [
+        KeyCode::KEY_A,
+        KeyCode::KEY_Z,
+        KeyCode::KEY_0,
+        KeyCode::KEY_9,
+        KeyCode::KEY_F1,
+        KeyCode::KEY_F24,
+        KeyCode::KEY_ENTER,
+        KeyCode::KEY_ESC,
+        KeyCode::KEY_SPACE,
+        KeyCode::KEY_LEFTCTRL,
+        KeyCode::KEY_RIGHTMETA,
+        KeyCode::KEY_VOLUMEUP,
+        KeyCode::KEY_PLAYPAUSE,
+        KeyCode::KEY_BACK,
+        KeyCode::KEY_KPENTER,
+    ];
+    for code in codes {
+        let key = code.to_key();
+        assert_ne!(key, Key::UNIDENTIFIED, "should map {code:?} to a key");
+        let back = key.to_key_code();
+        assert_eq!(back, code, "round-trip failed for {code:?}");
+    }
+}
+
+#[test]
+fn kbd_to_evdev_to_kbd_round_trip() {
+    let keys = [
+        Key::A,
+        Key::Z,
+        Key::DIGIT0,
+        Key::DIGIT9,
+        Key::F1,
+        Key::F24,
+        Key::ENTER,
+        Key::ESCAPE,
+        Key::SPACE,
+        Key::CONTROL_LEFT,
+        Key::META_RIGHT,
+        Key::AUDIO_VOLUME_UP,
+        Key::MEDIA_PLAY_PAUSE,
+        Key::BROWSER_BACK,
+        Key::NUMPAD_ENTER,
+    ];
+    for key in keys {
+        let code = key.to_key_code();
+        assert_ne!(code, KeyCode::KEY_UNKNOWN, "should map {key:?} to a code");
+        let back = code.to_key();
+        assert_eq!(back, key, "round-trip failed for {key:?}");
+    }
+}
+
+#[test]
+fn function_key_with_modifiers_dispatches() {
+    let mut dispatcher = Dispatcher::new();
+    dispatcher
+        .register(
+            Hotkey::new(Key::F5)
+                .modifier(Modifier::Ctrl)
+                .modifier(Modifier::Shift),
+            Action::Suppress,
+        )
+        .unwrap();
+
+    let key = KeyCode::KEY_F5.to_key();
+    let hotkey = Hotkey::new(key)
+        .modifier(Modifier::Ctrl)
+        .modifier(Modifier::Shift);
+    let result = dispatcher.process(&hotkey, KeyTransition::Press);
+    assert!(matches!(result, MatchResult::Matched { .. }));
+}
+
+#[test]
+fn string_parsed_and_converted_hotkeys_match() {
+    let parsed: Hotkey = "Ctrl+Shift+A".parse().unwrap();
+
+    let key = KeyCode::KEY_A.to_key();
+    let converted = Hotkey::new(key)
+        .modifier(Modifier::Ctrl)
+        .modifier(Modifier::Shift);
+
+    assert_eq!(parsed, converted);
+}
+
+#[test]
+fn media_key_converts_and_dispatches() {
+    let mut dispatcher = Dispatcher::new();
+    dispatcher
+        .register(Hotkey::new(Key::MEDIA_PLAY_PAUSE), Action::Suppress)
+        .unwrap();
+
+    let key = KeyCode::KEY_PLAYPAUSE.to_key();
+    let hotkey = Hotkey::new(key);
+    let result = dispatcher.process(&hotkey, KeyTransition::Press);
+    assert!(matches!(result, MatchResult::Matched { .. }));
+}
+
+#[test]
+fn browser_key_converts_and_dispatches() {
+    let mut dispatcher = Dispatcher::new();
+    dispatcher
+        .register(Hotkey::new(Key::BROWSER_BACK), Action::Suppress)
+        .unwrap();
+
+    let key = KeyCode::KEY_BACK.to_key();
+    let hotkey = Hotkey::new(key);
+    let result = dispatcher.process(&hotkey, KeyTransition::Press);
+    assert!(matches!(result, MatchResult::Matched { .. }));
+}


### PR DESCRIPTION
Applies the same pre-publish improvements made to kbd-crossterm (#79) and kbd-egui (#81).

## Changes

- **Sealed traits** — `EvdevKeyCodeExt` and `KbdKeyExt` now use a `private::Sealed` supertrait to prevent external implementations
- **`#[must_use]`** — Added to `to_key()` and `to_key_code()` trait methods
- **Prelude imports** — Updated doc examples, README, and example to use `kbd::prelude::*`
- **Doc fixes** — Fixed swapped re-export doc comments in `lib.rs`; cleaned up inaccurate `Action::EmitHotkey` reference in forwarder module docs
- **Unit tests** — Added 7 new tests covering digits, function keys, numpad, punctuation, navigation, CJK/international keys, and multiple unmapped keycodes
- **Integration tests** — Added `tests/public_api.rs` with 12 tests exercising import paths, dispatcher composition, round-trip conversions, and real workflows