### PR TITLE
refactor(kbd-iced): Prepare crate for v0.1.0 publish

### DIFF
--- a/crates/kbd-iced/README.md
+++ b/crates/kbd-iced/README.md
@@ -23,7 +23,7 @@ kbd-iced = "0.1"
 
 ```rust
 use iced_core::keyboard::{key::Code, Modifiers};
-use kbd::key::{Key, Modifier};
+use kbd::prelude::*;
 use kbd_iced::{IcedKeyExt, IcedModifiersExt};
 
 let key = Code::KeyA.to_key();

--- a/crates/kbd-iced/examples/iced.rs
+++ b/crates/kbd-iced/examples/iced.rs
@@ -11,12 +11,7 @@ use iced::Task;
 use iced::widget::column;
 use iced::widget::scrollable;
 use iced::widget::text;
-use kbd::dispatcher::Dispatcher;
-use kbd::dispatcher::MatchResult;
-use kbd::hotkey::Hotkey;
-use kbd::hotkey::Modifier;
-use kbd::key::Key;
-use kbd::key_state::KeyTransition;
+use kbd::prelude::*;
 use kbd_iced::IcedEventExt;
 
 fn main() -> iced::Result {

--- a/crates/kbd-iced/src/lib.rs
+++ b/crates/kbd-iced/src/lib.rs
@@ -47,8 +47,7 @@
 //!
 //! ```
 //! use iced_core::keyboard::{key::Code, Modifiers};
-//! use kbd::hotkey::Modifier;
-//! use kbd::key::Key;
+//! use kbd::prelude::*;
 //! use kbd_iced::{IcedKeyExt, IcedModifiersExt};
 //!
 //! // Code conversion
@@ -67,18 +66,28 @@ use kbd::hotkey::Hotkey;
 use kbd::hotkey::Modifier;
 use kbd::key::Key;
 
+mod private {
+    pub trait Sealed {}
+    impl Sealed for iced_core::keyboard::key::Code {}
+    impl Sealed for iced_core::keyboard::key::Physical {}
+    impl Sealed for iced_core::keyboard::Modifiers {}
+    impl Sealed for iced_core::keyboard::Event {}
+}
+
 /// Convert an iced physical key type to a `kbd` [`Key`].
 ///
 /// Returns `None` for keys that have no `kbd` equivalent (e.g.,
 /// `Unidentified`, keys beyond F24, international input keys).
-pub trait IcedKeyExt {
+///
+/// This trait is sealed and cannot be implemented outside this crate.
+pub trait IcedKeyExt: private::Sealed {
     /// Convert this iced key to a `kbd` [`Key`], or `None` if unmappable.
     ///
     /// # Examples
     ///
     /// ```
     /// use iced_core::keyboard::key;
-    /// use kbd::key::Key;
+    /// use kbd::prelude::*;
     /// use kbd_iced::IcedKeyExt;
     ///
     /// assert_eq!(key::Code::KeyA.to_key(), Some(Key::A));
@@ -87,6 +96,7 @@ pub trait IcedKeyExt {
     /// let physical = key::Physical::Code(key::Code::Enter);
     /// assert_eq!(physical.to_key(), Some(Key::ENTER));
     /// ```
+    #[must_use]
     fn to_key(&self) -> Option<Key>;
 }
 
@@ -334,19 +344,22 @@ impl IcedKeyExt for key::Physical {
 ///
 /// Iced uses `LOGO` for the Super/Meta/Windows key. This maps to
 /// `Modifier::Super` in `kbd`.
-pub trait IcedModifiersExt {
+///
+/// This trait is sealed and cannot be implemented outside this crate.
+pub trait IcedModifiersExt: private::Sealed {
     /// Convert these iced modifier flags to a `Vec<Modifier>`.
     ///
     /// # Examples
     ///
     /// ```
     /// use iced_core::keyboard::Modifiers;
-    /// use kbd::hotkey::Modifier;
+    /// use kbd::prelude::*;
     /// use kbd_iced::IcedModifiersExt;
     ///
     /// let mods = (Modifiers::CTRL | Modifiers::SHIFT).to_modifiers();
     /// assert_eq!(mods, vec![Modifier::Ctrl, Modifier::Shift]);
     /// ```
+    #[must_use]
     fn to_modifiers(&self) -> Vec<Modifier>;
 }
 
@@ -379,15 +392,15 @@ impl IcedModifiersExt for Modifiers {
 /// corresponding modifier flag is stripped from the modifiers — iced
 /// includes the pressed modifier key in its own modifier state, but
 /// `kbd` treats the key as the trigger, not as a modifier of itself.
-pub trait IcedEventExt {
+/// This trait is sealed and cannot be implemented outside this crate.
+pub trait IcedEventExt: private::Sealed {
     /// Convert this keyboard event to a [`Hotkey`], or `None` if unmappable.
     ///
     /// # Examples
     ///
     /// ```
     /// use iced_core::keyboard::{Event, Location, Modifiers, key};
-    /// use kbd::hotkey::{Hotkey, Modifier};
-    /// use kbd::key::Key;
+    /// use kbd::prelude::*;
     /// use kbd_iced::IcedEventExt;
     ///
     /// let event = Event::KeyPressed {
@@ -404,6 +417,7 @@ pub trait IcedEventExt {
     ///     Some(Hotkey::new(Key::S).modifier(Modifier::Ctrl)),
     /// );
     /// ```
+    #[must_use]
     fn to_hotkey(&self) -> Option<Hotkey>;
 }
 

--- a/crates/kbd-iced/tests/public_api.rs
+++ b/crates/kbd-iced/tests/public_api.rs
@@ -1,0 +1,222 @@
+//! Integration tests that exercise kbd-iced's public API as an outside consumer would.
+//!
+//! These complement the unit tests in lib.rs by verifying that:
+//! - Import paths work as documented
+//! - Converted types compose correctly with kbd's dispatcher
+//! - Real workflows (convert event → register → process → match) hold together
+
+use iced_core::keyboard::Event;
+use iced_core::keyboard::Location;
+use iced_core::keyboard::Modifiers;
+use iced_core::keyboard::key;
+use kbd::prelude::*;
+use kbd_iced::IcedEventExt;
+use kbd_iced::IcedKeyExt;
+use kbd_iced::IcedModifiersExt;
+
+fn key_pressed(code: key::Code, modifiers: Modifiers) -> Event {
+    Event::KeyPressed {
+        key: iced_core::keyboard::Key::Unidentified,
+        modified_key: iced_core::keyboard::Key::Unidentified,
+        physical_key: key::Physical::Code(code),
+        location: Location::Standard,
+        modifiers,
+        text: None,
+        repeat: false,
+    }
+}
+
+#[test]
+fn convert_and_dispatch_simple_hotkey() {
+    let mut dispatcher = Dispatcher::new();
+    dispatcher
+        .register(
+            Hotkey::new(Key::S).modifier(Modifier::Ctrl),
+            Action::Suppress,
+        )
+        .unwrap();
+
+    let event = key_pressed(key::Code::KeyS, Modifiers::CTRL);
+    let hotkey = event.to_hotkey().unwrap();
+    let result = dispatcher.process(&hotkey, KeyTransition::Press);
+    assert!(matches!(result, MatchResult::Matched { .. }));
+}
+
+#[test]
+fn convert_and_dispatch_multi_modifier_hotkey() {
+    let mut dispatcher = Dispatcher::new();
+    dispatcher
+        .register(
+            Hotkey::new(Key::A)
+                .modifier(Modifier::Ctrl)
+                .modifier(Modifier::Shift),
+            Action::Suppress,
+        )
+        .unwrap();
+
+    let event = key_pressed(key::Code::KeyA, Modifiers::CTRL | Modifiers::SHIFT);
+    let hotkey = event.to_hotkey().unwrap();
+    let result = dispatcher.process(&hotkey, KeyTransition::Press);
+    assert!(matches!(result, MatchResult::Matched { .. }));
+}
+
+#[test]
+fn unregistered_hotkey_does_not_match() {
+    let mut dispatcher = Dispatcher::new();
+    dispatcher
+        .register(
+            Hotkey::new(Key::S).modifier(Modifier::Ctrl),
+            Action::Suppress,
+        )
+        .unwrap();
+
+    let event = key_pressed(key::Code::KeyQ, Modifiers::CTRL);
+    let hotkey = event.to_hotkey().unwrap();
+    let result = dispatcher.process(&hotkey, KeyTransition::Press);
+    assert!(matches!(result, MatchResult::NoMatch));
+}
+
+#[test]
+fn unidentified_key_event_returns_none() {
+    let event = Event::KeyPressed {
+        key: iced_core::keyboard::Key::Unidentified,
+        modified_key: iced_core::keyboard::Key::Unidentified,
+        physical_key: key::Physical::Unidentified(key::NativeCode::Unidentified),
+        location: Location::Standard,
+        modifiers: Modifiers::empty(),
+        text: None,
+        repeat: false,
+    };
+    assert!(event.to_hotkey().is_none());
+}
+
+#[test]
+fn modifiers_changed_event_returns_none() {
+    let event = Event::ModifiersChanged(Modifiers::CTRL);
+    assert!(event.to_hotkey().is_none());
+}
+
+#[test]
+fn converted_hotkey_equals_manually_built() {
+    let event = key_pressed(key::Code::KeyC, Modifiers::CTRL | Modifiers::ALT);
+    let from_event = event.to_hotkey().unwrap();
+    let manual = Hotkey::new(Key::C)
+        .modifier(Modifier::Ctrl)
+        .modifier(Modifier::Alt);
+    assert_eq!(from_event, manual);
+}
+
+#[test]
+fn trait_methods_are_independently_composable() {
+    let key = key::Code::KeyX.to_key().unwrap();
+    let mods = (Modifiers::CTRL | Modifiers::SHIFT).to_modifiers();
+    let hotkey = Hotkey::with_modifiers(key, mods);
+
+    let expected = Hotkey::new(Key::X)
+        .modifier(Modifier::Ctrl)
+        .modifier(Modifier::Shift);
+    assert_eq!(hotkey, expected);
+}
+
+#[test]
+fn function_key_with_modifiers_roundtrip() {
+    let mut dispatcher = Dispatcher::new();
+    dispatcher
+        .register(
+            Hotkey::new(Key::F5)
+                .modifier(Modifier::Ctrl)
+                .modifier(Modifier::Shift),
+            Action::Suppress,
+        )
+        .unwrap();
+
+    let event = key_pressed(key::Code::F5, Modifiers::CTRL | Modifiers::SHIFT);
+    let hotkey = event.to_hotkey().unwrap();
+    let result = dispatcher.process(&hotkey, KeyTransition::Press);
+    assert!(matches!(result, MatchResult::Matched { .. }));
+}
+
+#[test]
+fn string_parsed_and_converted_hotkeys_match() {
+    let parsed: Hotkey = "Ctrl+Shift+A".parse().unwrap();
+
+    let event = key_pressed(key::Code::KeyA, Modifiers::CTRL | Modifiers::SHIFT);
+    let converted = event.to_hotkey().unwrap();
+
+    assert_eq!(parsed, converted);
+}
+
+#[test]
+fn key_release_also_converts() {
+    let event = Event::KeyReleased {
+        key: iced_core::keyboard::Key::Unidentified,
+        modified_key: iced_core::keyboard::Key::Unidentified,
+        physical_key: key::Physical::Code(key::Code::KeyC),
+        location: Location::Standard,
+        modifiers: Modifiers::CTRL,
+    };
+    let hotkey = event.to_hotkey().unwrap();
+    assert_eq!(hotkey, Hotkey::new(Key::C).modifier(Modifier::Ctrl));
+}
+
+#[test]
+fn modifier_key_strips_self_from_modifiers() {
+    // iced includes SHIFT in modifiers when ShiftLeft is pressed.
+    // The conversion should strip the self-modifier so the hotkey is
+    // just ShiftLeft, not Shift+ShiftLeft.
+    let event = key_pressed(key::Code::ShiftLeft, Modifiers::SHIFT);
+    let hotkey = event.to_hotkey().unwrap();
+    assert_eq!(hotkey, Hotkey::new(Key::SHIFT_LEFT));
+}
+
+#[test]
+fn modifier_key_keeps_other_modifiers() {
+    // Pressing ControlLeft while Shift is already held
+    let event = key_pressed(key::Code::ControlLeft, Modifiers::SHIFT | Modifiers::CTRL);
+    let hotkey = event.to_hotkey().unwrap();
+    assert_eq!(
+        hotkey,
+        Hotkey::new(Key::CONTROL_LEFT).modifier(Modifier::Shift)
+    );
+}
+
+#[test]
+fn logo_maps_to_super_in_dispatch() {
+    let mut dispatcher = Dispatcher::new();
+    dispatcher
+        .register(
+            Hotkey::new(Key::S).modifier(Modifier::Super),
+            Action::Suppress,
+        )
+        .unwrap();
+
+    let event = key_pressed(key::Code::KeyS, Modifiers::LOGO);
+    let hotkey = event.to_hotkey().unwrap();
+    let result = dispatcher.process(&hotkey, KeyTransition::Press);
+    assert!(matches!(result, MatchResult::Matched { .. }));
+}
+
+#[test]
+fn media_key_converts_and_dispatches() {
+    let mut dispatcher = Dispatcher::new();
+    dispatcher
+        .register(Hotkey::new(Key::MEDIA_PLAY_PAUSE), Action::Suppress)
+        .unwrap();
+
+    let event = key_pressed(key::Code::MediaPlayPause, Modifiers::empty());
+    let hotkey = event.to_hotkey().unwrap();
+    let result = dispatcher.process(&hotkey, KeyTransition::Press);
+    assert!(matches!(result, MatchResult::Matched { .. }));
+}
+
+#[test]
+fn physical_code_wrapper_converts() {
+    let physical = key::Physical::Code(key::Code::KeyA);
+    assert_eq!(physical.to_key(), Some(Key::A));
+}
+
+#[test]
+fn physical_unidentified_returns_none() {
+    let physical = key::Physical::Unidentified(key::NativeCode::Unidentified);
+    assert_eq!(physical.to_key(), None);
+}


### PR DESCRIPTION
Brings kbd-iced in line with the patterns established in the other bridge crate refactors (kbd-crossterm, kbd-egui, kbd-evdev, kbd-global).

## Changes

- **Seal extension traits** — `IcedKeyExt`, `IcedModifiersExt`, `IcedEventExt` now use `private::Sealed` to prevent downstream implementations
- **Add `#[must_use]`** on all trait method definitions (`to_key()`, `to_modifiers()`, `to_hotkey()`)
- **Use `kbd::prelude::*`** in module docs, trait doc examples, README, and `examples/iced.rs`
- **Fix README bug** — usage example had `use kbd::key::{Key, Modifier}` but `Modifier` lives at `kbd::hotkey::Modifier`
- **Add `tests/public_api.rs`** — 16 integration tests exercising the full outside-consumer workflow:
  - Convert iced events → register hotkeys → dispatch → assert matches
  - Simple and multi-modifier hotkeys
  - Unregistered / unidentified / `ModifiersChanged` → no match
  - Key release events
  - Modifier self-stripping (e.g. ShiftLeft pressed with SHIFT active)
  - LOGO → Super mapping
  - Media key dispatch
  - String-parsed hotkey equality
  - Independent trait composition (`to_key()` + `to_modifiers()` → `Hotkey::with_modifiers`)

## Test results

47 total (27 unit + 16 integration + 4 doctests), all passing. Clippy and fmt clean.