### PR TITLE
refactor(kbd-tao): Prepare crate for v0.1.0 publish

### DIFF
--- a/crates/kbd-tao/README.md
+++ b/crates/kbd-tao/README.md
@@ -5,6 +5,8 @@
 
 [`kbd`](https://crates.io/crates/kbd) bridge for [tao](https://docs.rs/tao) (Tauri's winit fork) — converts key events and modifiers to `kbd` types.
 
+This lets window-focused key events (from tao) and global hotkey events (from [`kbd-global`](https://docs.rs/kbd-global)) feed into the same `Dispatcher`. Especially useful in Tauri apps where you want both in-window shortcuts and system-wide hotkeys handled through a single hotkey registry.
+
 Tao is Tauri's fork of winit — both derive from the W3C UI Events specification, so the variant names are nearly identical and the mapping is mechanical. Unlike winit, tao uses `KeyCode` directly in `KeyEvent` rather than wrapping it in a `PhysicalKey` type.
 
 ```toml
@@ -21,8 +23,40 @@ kbd-tao = "0.1"
 
 ## Usage
 
+Inside tao's event loop, use `TaoEventExt` to convert key events directly:
+
+```rust,no_run
+use kbd::prelude::*;
+use kbd_tao::TaoEventExt;
+use tao::event::{Event, WindowEvent};
+use tao::event_loop::{ControlFlow, EventLoop};
+use tao::keyboard::ModifiersState;
+use tao::window::WindowBuilder;
+
+let event_loop = EventLoop::new();
+let _window = WindowBuilder::new().build(&event_loop).unwrap();
+let mut modifiers = ModifiersState::empty();
+
+event_loop.run(move |event, _, control_flow| {
+    *control_flow = ControlFlow::Wait;
+    if let Event::WindowEvent { event, .. } = event {
+        match event {
+            WindowEvent::ModifiersChanged(mods) => modifiers = mods,
+            WindowEvent::KeyboardInput { event, .. } => {
+                if let Some(hotkey) = event.to_hotkey(modifiers) {
+                    println!("{hotkey}");
+                }
+            }
+            _ => {}
+        }
+    }
+});
+```
+
+The individual conversion traits can also be used separately:
+
 ```rust
-use kbd::key::{Key, Modifier};
+use kbd::prelude::*;
 use kbd_tao::{TaoKeyExt, TaoModifiersExt};
 use tao::keyboard::{KeyCode, ModifiersState};
 

--- a/crates/kbd-tao/examples/tao.rs
+++ b/crates/kbd-tao/examples/tao.rs
@@ -5,13 +5,7 @@
 //! cargo run -p kbd-tao --example tao
 //! ```
 
-use kbd::action::Action;
-use kbd::dispatcher::Dispatcher;
-use kbd::dispatcher::MatchResult;
-use kbd::hotkey::Hotkey;
-use kbd::hotkey::Modifier;
-use kbd::key::Key;
-use kbd::key_state::KeyTransition;
+use kbd::prelude::*;
 use kbd_tao::TaoEventExt;
 use tao::event::Event;
 use tao::event::WindowEvent;

--- a/crates/kbd-tao/src/lib.rs
+++ b/crates/kbd-tao/src/lib.rs
@@ -2,13 +2,17 @@
 
 //! Tao key event conversions for `kbd`.
 //!
-//! This crate bridges tao's physical key model to `kbd`'s key types.
+//! This crate converts tao's key events into `kbd`'s unified types so
+//! that window-focused key events (from tao) and global hotkey events
+//! (from [`kbd-global`](https://docs.rs/kbd-global)) can feed into the
+//! same [`Dispatcher`](kbd::dispatcher::Dispatcher). This is especially
+//! useful in Tauri apps where you want both in-window shortcuts and
+//! system-wide hotkeys handled through a single hotkey registry.
+//!
 //! tao is Tauri's fork of winit — both derive from the W3C UI Events
 //! specification, so the variant names are nearly identical and the
-//! mapping is mechanical.
-//!
-//! Unlike winit, tao uses [`KeyCode`] directly in [`KeyEvent`] rather
-//! than wrapping it in a `PhysicalKey` type.
+//! mapping is mechanical. Unlike winit, tao uses [`KeyCode`] directly
+//! in [`KeyEvent`] rather than wrapping it in a `PhysicalKey` type.
 //!
 //! # Extension traits
 //!
@@ -45,17 +49,47 @@
 //!
 //! # Usage
 //!
+//! Inside tao's event loop, use [`TaoEventExt`] to convert key events
+//! directly:
+//!
+//! ```no_run
+//! use kbd::prelude::*;
+//! use kbd_tao::TaoEventExt;
+//! use tao::event::{Event, WindowEvent};
+//! use tao::event_loop::{ControlFlow, EventLoop};
+//! use tao::keyboard::ModifiersState;
+//! use tao::window::WindowBuilder;
+//!
+//! let event_loop = EventLoop::new();
+//! let _window = WindowBuilder::new().build(&event_loop).unwrap();
+//! let mut modifiers = ModifiersState::empty();
+//!
+//! event_loop.run(move |event, _, control_flow| {
+//!     *control_flow = ControlFlow::Wait;
+//!     if let Event::WindowEvent { event, .. } = event {
+//!         match event {
+//!             WindowEvent::ModifiersChanged(mods) => modifiers = mods,
+//!             WindowEvent::KeyboardInput { event, .. } => {
+//!                 if let Some(hotkey) = event.to_hotkey(modifiers) {
+//!                     println!("{hotkey}");
+//!                 }
+//!             }
+//!             _ => {}
+//!         }
+//!     }
+//! });
 //! ```
-//! use kbd::hotkey::{Hotkey, Modifier};
-//! use kbd::key::Key;
+//!
+//! The individual conversion traits can also be used separately:
+//!
+//! ```
+//! use kbd::prelude::*;
 //! use kbd_tao::{TaoKeyExt, TaoModifiersExt};
 //! use tao::keyboard::{KeyCode, ModifiersState};
 //!
-//! // KeyCode conversion
 //! let key = KeyCode::KeyA.to_key();
 //! assert_eq!(key, Some(Key::A));
 //!
-//! // Modifier conversion
 //! let mods = ModifiersState::CONTROL.to_modifiers();
 //! assert_eq!(mods, vec![Modifier::Ctrl]);
 //! ```
@@ -67,17 +101,26 @@ use tao::event::KeyEvent;
 use tao::keyboard::KeyCode;
 use tao::keyboard::ModifiersState;
 
+mod private {
+    pub trait Sealed {}
+    impl Sealed for tao::keyboard::KeyCode {}
+    impl Sealed for tao::keyboard::ModifiersState {}
+    impl Sealed for tao::event::KeyEvent {}
+}
+
 /// Convert a tao key type to a `kbd` [`Key`].
 ///
 /// Returns `None` for keys that have no `kbd` equivalent (e.g.,
 /// `Unidentified`, keys beyond F24).
-pub trait TaoKeyExt {
+///
+/// This trait is sealed and cannot be implemented outside this crate.
+pub trait TaoKeyExt: private::Sealed {
     /// Convert this tao key code to a `kbd` [`Key`], or `None` if unmappable.
     ///
     /// # Examples
     ///
     /// ```
-    /// use kbd::key::Key;
+    /// use kbd::prelude::*;
     /// use kbd_tao::TaoKeyExt;
     /// use tao::keyboard::KeyCode;
     ///
@@ -85,6 +128,7 @@ pub trait TaoKeyExt {
     /// assert_eq!(KeyCode::F5.to_key(), Some(Key::F5));
     /// assert_eq!(KeyCode::SuperLeft.to_key(), Some(Key::META_LEFT));
     /// ```
+    #[must_use]
     fn to_key(&self) -> Option<Key>;
 }
 
@@ -319,19 +363,22 @@ impl TaoKeyExt for KeyCode {
 }
 
 /// Convert tao [`ModifiersState`] bitflags to a sorted `Vec<Modifier>`.
-pub trait TaoModifiersExt {
+///
+/// This trait is sealed and cannot be implemented outside this crate.
+pub trait TaoModifiersExt: private::Sealed {
     /// Convert these tao modifier flags to a `Vec<Modifier>`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use kbd::hotkey::Modifier;
+    /// use kbd::prelude::*;
     /// use kbd_tao::TaoModifiersExt;
     /// use tao::keyboard::ModifiersState;
     ///
     /// let mods = (ModifiersState::CONTROL | ModifiersState::SHIFT).to_modifiers();
     /// assert_eq!(mods, vec![Modifier::Ctrl, Modifier::Shift]);
     /// ```
+    #[must_use]
     fn to_modifiers(&self) -> Vec<Modifier>;
 }
 
@@ -356,8 +403,11 @@ impl TaoModifiersExt for ModifiersState {
 
 /// Build a [`Hotkey`] from a tao key code and modifier state.
 ///
-/// This is the logic behind [`TaoEventExt::to_hotkey`], exposed as a
-/// standalone function for use when a [`KeyEvent`] is not available.
+/// This is the same conversion performed by [`TaoEventExt::to_hotkey`],
+/// exposed as a standalone function for use when you have a raw
+/// [`KeyCode`] and [`ModifiersState`] but no [`KeyEvent`]. If you do
+/// have a `KeyEvent`, prefer calling [`event.to_hotkey(modifiers)`](TaoEventExt::to_hotkey)
+/// instead.
 ///
 /// When the key is itself a modifier (e.g., `ControlLeft`), the
 /// corresponding modifier flag is stripped — tao includes the pressed
@@ -390,7 +440,9 @@ pub fn tao_key_to_hotkey(keycode: KeyCode, modifiers: ModifiersState) -> Option<
 /// corresponding modifier flag is stripped from the modifiers — tao
 /// includes the pressed modifier key in its own state, but `kbd`
 /// treats the key as the trigger, not as a modifier of itself.
-pub trait TaoEventExt {
+///
+/// This trait is sealed and cannot be implemented outside this crate.
+pub trait TaoEventExt: private::Sealed {
     /// Convert this key event to a [`Hotkey`], or `None` if the key is unmappable.
     ///
     /// Pass the current [`ModifiersState`] from
@@ -398,18 +450,43 @@ pub trait TaoEventExt {
     ///
     /// # Examples
     ///
-    /// ```
-    /// use kbd::hotkey::{Hotkey, Modifier};
-    /// use kbd::key::Key;
-    /// use kbd_tao::tao_key_to_hotkey;
-    /// use tao::keyboard::{KeyCode, ModifiersState};
+    /// Tao's [`KeyEvent`] cannot be constructed outside the tao crate
+    /// (it has a `pub(crate)` field), so this trait is used inside
+    /// tao's event loop where the framework provides the event:
     ///
-    /// let hotkey = tao_key_to_hotkey(KeyCode::KeyS, ModifiersState::CONTROL);
-    /// assert_eq!(
-    ///     hotkey,
-    ///     Some(Hotkey::new(Key::S).modifier(Modifier::Ctrl)),
-    /// );
+    /// ```no_run
+    /// use kbd::prelude::*;
+    /// use kbd_tao::TaoEventExt;
+    /// use tao::event::{Event, WindowEvent};
+    /// use tao::event_loop::{ControlFlow, EventLoop};
+    /// use tao::keyboard::ModifiersState;
+    /// use tao::window::WindowBuilder;
+    ///
+    /// let event_loop = EventLoop::new();
+    /// let _window = WindowBuilder::new().build(&event_loop).unwrap();
+    /// let mut modifiers = ModifiersState::empty();
+    ///
+    /// event_loop.run(move |event, _, control_flow| {
+    ///     *control_flow = ControlFlow::Wait;
+    ///     if let Event::WindowEvent { event, .. } = event {
+    ///         match event {
+    ///             WindowEvent::ModifiersChanged(mods) => modifiers = mods,
+    ///             WindowEvent::KeyboardInput { event, .. } => {
+    ///                 // Convert the tao KeyEvent to a kbd Hotkey
+    ///                 if let Some(hotkey) = event.to_hotkey(modifiers) {
+    ///                     println!("{hotkey}");
+    ///                 }
+    ///             }
+    ///             _ => {}
+    ///         }
+    ///     }
+    /// });
     /// ```
+    ///
+    /// When you have a [`KeyCode`] and [`ModifiersState`] but no
+    /// [`KeyEvent`], use the standalone [`tao_key_to_hotkey`] function
+    /// instead.
+    #[must_use]
     fn to_hotkey(&self, modifiers: ModifiersState) -> Option<Hotkey>;
 }
 

--- a/crates/kbd-tao/tests/public_api.rs
+++ b/crates/kbd-tao/tests/public_api.rs
@@ -1,0 +1,187 @@
+//! Integration tests that exercise kbd-tao's public API as an outside consumer would.
+//!
+//! These complement the unit tests in lib.rs by verifying that:
+//! - Import paths work as documented
+//! - Converted types compose correctly with kbd's dispatcher
+//! - Real workflows (convert → register → process → match) hold together
+//!
+//! Note: tao's `KeyEvent` has a `pub(crate)` field (`platform_specific`)
+//! that prevents direct construction outside the tao crate. These tests
+//! exercise the public `tao_key_to_hotkey` function and the individual
+//! extension traits instead. The `TaoEventExt` trait is tested via unit
+//! tests in lib.rs where we can validate the delegation.
+
+use kbd::prelude::*;
+use kbd_tao::TaoKeyExt;
+use kbd_tao::TaoModifiersExt;
+use kbd_tao::tao_key_to_hotkey;
+use tao::keyboard::KeyCode;
+use tao::keyboard::ModifiersState;
+
+#[test]
+fn convert_and_dispatch_simple_hotkey() {
+    let mut dispatcher = Dispatcher::new();
+    dispatcher
+        .register(
+            Hotkey::new(Key::S).modifier(Modifier::Ctrl),
+            Action::Suppress,
+        )
+        .unwrap();
+
+    let hotkey = tao_key_to_hotkey(KeyCode::KeyS, ModifiersState::CONTROL).unwrap();
+    let result = dispatcher.process(&hotkey, KeyTransition::Press);
+    assert!(matches!(result, MatchResult::Matched { .. }));
+}
+
+#[test]
+fn convert_and_dispatch_multi_modifier_hotkey() {
+    let mut dispatcher = Dispatcher::new();
+    dispatcher
+        .register(
+            Hotkey::new(Key::A)
+                .modifier(Modifier::Ctrl)
+                .modifier(Modifier::Shift),
+            Action::Suppress,
+        )
+        .unwrap();
+
+    let mods = ModifiersState::CONTROL | ModifiersState::SHIFT;
+    let hotkey = tao_key_to_hotkey(KeyCode::KeyA, mods).unwrap();
+    let result = dispatcher.process(&hotkey, KeyTransition::Press);
+    assert!(matches!(result, MatchResult::Matched { .. }));
+}
+
+#[test]
+fn unregistered_hotkey_does_not_match() {
+    let mut dispatcher = Dispatcher::new();
+    dispatcher
+        .register(
+            Hotkey::new(Key::S).modifier(Modifier::Ctrl),
+            Action::Suppress,
+        )
+        .unwrap();
+
+    let hotkey = tao_key_to_hotkey(KeyCode::KeyQ, ModifiersState::CONTROL).unwrap();
+    let result = dispatcher.process(&hotkey, KeyTransition::Press);
+    assert!(matches!(result, MatchResult::NoMatch));
+}
+
+#[test]
+fn unidentified_key_returns_none() {
+    let hotkey = tao_key_to_hotkey(
+        KeyCode::Unidentified(tao::keyboard::NativeKeyCode::Unidentified),
+        ModifiersState::empty(),
+    );
+    assert!(hotkey.is_none());
+}
+
+#[test]
+fn converted_hotkey_equals_manually_built() {
+    let mods = ModifiersState::CONTROL | ModifiersState::ALT;
+    let from_fn = tao_key_to_hotkey(KeyCode::KeyC, mods).unwrap();
+    let manual = Hotkey::new(Key::C)
+        .modifier(Modifier::Ctrl)
+        .modifier(Modifier::Alt);
+    assert_eq!(from_fn, manual);
+}
+
+#[test]
+fn trait_methods_are_independently_composable() {
+    let key = KeyCode::KeyX.to_key().unwrap();
+    let mods = (ModifiersState::CONTROL | ModifiersState::SHIFT).to_modifiers();
+    let hotkey = Hotkey::with_modifiers(key, mods);
+
+    let expected = Hotkey::new(Key::X)
+        .modifier(Modifier::Ctrl)
+        .modifier(Modifier::Shift);
+    assert_eq!(hotkey, expected);
+}
+
+#[test]
+fn function_key_with_modifiers_roundtrip() {
+    let mut dispatcher = Dispatcher::new();
+    dispatcher
+        .register(
+            Hotkey::new(Key::F5)
+                .modifier(Modifier::Ctrl)
+                .modifier(Modifier::Shift),
+            Action::Suppress,
+        )
+        .unwrap();
+
+    let mods = ModifiersState::CONTROL | ModifiersState::SHIFT;
+    let hotkey = tao_key_to_hotkey(KeyCode::F5, mods).unwrap();
+    let result = dispatcher.process(&hotkey, KeyTransition::Press);
+    assert!(matches!(result, MatchResult::Matched { .. }));
+}
+
+#[test]
+fn string_parsed_and_converted_hotkeys_match() {
+    let parsed: Hotkey = "Ctrl+Shift+A".parse().unwrap();
+
+    let mods = ModifiersState::CONTROL | ModifiersState::SHIFT;
+    let converted = tao_key_to_hotkey(KeyCode::KeyA, mods).unwrap();
+
+    assert_eq!(parsed, converted);
+}
+
+#[test]
+fn modifier_key_strips_self_from_modifiers() {
+    // tao includes SHIFT in ModifiersState when ShiftLeft is pressed.
+    // The conversion should strip the self-modifier so the hotkey is
+    // just ShiftLeft, not Shift+ShiftLeft.
+    let hotkey = tao_key_to_hotkey(KeyCode::ShiftLeft, ModifiersState::SHIFT).unwrap();
+    assert_eq!(hotkey, Hotkey::new(Key::SHIFT_LEFT));
+}
+
+#[test]
+fn modifier_key_keeps_other_modifiers() {
+    // Pressing ControlLeft while Shift is already held
+    let mods = ModifiersState::SHIFT | ModifiersState::CONTROL;
+    let hotkey = tao_key_to_hotkey(KeyCode::ControlLeft, mods).unwrap();
+    assert_eq!(
+        hotkey,
+        Hotkey::new(Key::CONTROL_LEFT).modifier(Modifier::Shift)
+    );
+}
+
+#[test]
+fn super_maps_to_super_in_dispatch() {
+    let mut dispatcher = Dispatcher::new();
+    dispatcher
+        .register(
+            Hotkey::new(Key::S).modifier(Modifier::Super),
+            Action::Suppress,
+        )
+        .unwrap();
+
+    let hotkey = tao_key_to_hotkey(KeyCode::KeyS, ModifiersState::SUPER).unwrap();
+    let result = dispatcher.process(&hotkey, KeyTransition::Press);
+    assert!(matches!(result, MatchResult::Matched { .. }));
+}
+
+#[test]
+fn media_key_converts_and_dispatches() {
+    let mut dispatcher = Dispatcher::new();
+    dispatcher
+        .register(Hotkey::new(Key::MEDIA_PLAY_PAUSE), Action::Suppress)
+        .unwrap();
+
+    let hotkey = tao_key_to_hotkey(KeyCode::MediaPlayPause, ModifiersState::empty()).unwrap();
+    let result = dispatcher.process(&hotkey, KeyTransition::Press);
+    assert!(matches!(result, MatchResult::Matched { .. }));
+}
+
+#[test]
+fn super_left_right_maps_to_meta() {
+    // tao's SuperLeft/SuperRight → kbd's META_LEFT/META_RIGHT
+    assert_eq!(KeyCode::SuperLeft.to_key(), Some(Key::META_LEFT));
+    assert_eq!(KeyCode::SuperRight.to_key(), Some(Key::META_RIGHT));
+}
+
+#[test]
+fn super_key_strips_self() {
+    // Pressing SuperLeft — tao reports SUPER in ModifiersState.
+    let hotkey = tao_key_to_hotkey(KeyCode::SuperLeft, ModifiersState::SUPER).unwrap();
+    assert_eq!(hotkey, Hotkey::new(Key::META_LEFT));
+}


### PR DESCRIPTION
## Changes

- **Seal extension traits** (TaoKeyExt, TaoModifiersExt, TaoEventExt) with `private::Sealed` to prevent downstream implementations
- **Add `#[must_use]`** to all trait method signatures
- **Use `kbd::prelude::*`** in doc examples, README, and example code
- **Fix TaoEventExt doc example** to show actual trait usage in tao's event loop (`no_run`) instead of the standalone function — tao's `KeyEvent` has a `pub(crate)` field preventing construction outside tao
- **Clarify standalone `tao_key_to_hotkey` docs** to explain when to use it vs the trait method
- **Add motivation to crate-level docs and README** — explains that this lets window-focused events (tao) and global hotkey events (kbd-global) feed into the same `Dispatcher`, the primary use case for Tauri apps
- **Add integration tests** (`tests/public_api.rs`) covering dispatcher roundtrips, modifier self-stripping, unidentified keys, string-parsed vs converted equality, Super/Meta mapping, media keys, and trait composability

## Test results

42 tests pass (23 unit + 14 integration + 5 doctests), clippy clean, fmt clean.