### PR TITLE
docs: Add motivation to bridge crate docs and restructure root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,25 @@ A keyboard shortcut engine for Rust. You describe the shortcuts you care about, 
 
 ## Crates
 
+### Core
+
 | Crate | | |
 |---|---|---|
-| [`kbd`](crates/kbd) | [![crates.io](https://img.shields.io/crates/v/kbd.svg)](https://crates.io/crates/kbd) | Core engine — key types, dispatcher, layers, string parsing |
-| [`kbd-crossterm`](crates/kbd-crossterm) | [![crates.io](https://img.shields.io/crates/v/kbd-crossterm.svg)](https://crates.io/crates/kbd-crossterm) | [crossterm](https://docs.rs/crossterm) bridge |
-| [`kbd-egui`](crates/kbd-egui) | [![crates.io](https://img.shields.io/crates/v/kbd-egui.svg)](https://crates.io/crates/kbd-egui) | [egui](https://docs.rs/egui) bridge |
-| [`kbd-evdev`](crates/kbd-evdev) | [![crates.io](https://img.shields.io/crates/v/kbd-evdev.svg)](https://crates.io/crates/kbd-evdev) | Linux evdev backend (device discovery, hotplug, grab, forwarding) |
-| [`kbd-global`](crates/kbd-global) | [![crates.io](https://img.shields.io/crates/v/kbd-global.svg)](https://crates.io/crates/kbd-global) | Linux global hotkey runtime (evdev, grab mode, hotplug) |
-| [`kbd-iced`](crates/kbd-iced) | [![crates.io](https://img.shields.io/crates/v/kbd-iced.svg)](https://crates.io/crates/kbd-iced) | [iced](https://docs.rs/iced) bridge |
-| [`kbd-tao`](crates/kbd-tao) | [![crates.io](https://img.shields.io/crates/v/kbd-tao.svg)](https://crates.io/crates/kbd-tao) | [tao](https://docs.rs/tao) bridge (Tauri) |
-| [`kbd-winit`](crates/kbd-winit) | [![crates.io](https://img.shields.io/crates/v/kbd-winit.svg)](https://crates.io/crates/kbd-winit) | [winit](https://docs.rs/winit) bridge |
+| [`kbd`](crates/kbd) | [![crates.io](https://img.shields.io/crates/v/kbd.svg)](https://crates.io/crates/kbd) | Core engine — key types, hotkeys, dispatcher, layers, string parsing |
+| [`kbd-evdev`](crates/kbd-evdev) | [![crates.io](https://img.shields.io/crates/v/kbd-evdev.svg)](https://crates.io/crates/kbd-evdev) | Linux evdev backend — device discovery, hotplug, grab, forwarding |
+| [`kbd-global`](crates/kbd-global) | [![crates.io](https://img.shields.io/crates/v/kbd-global.svg)](https://crates.io/crates/kbd-global) | System-wide hotkeys on Linux (evdev, grab mode, hotplug) |
 
-The core [`kbd`](crates/kbd) crate has no platform dependencies and works synchronously in any event loop. Bridge crates convert framework key events into `kbd` types. [`kbd-global`](crates/kbd-global) adds system-wide hotkeys on Linux.
+### Bridges
+
+Bridge crates convert framework key events into `kbd` types. Use one alongside the core crates — for example, `kbd-tao` + `kbd-global` gives a Tauri app both in-window shortcuts and system-wide hotkeys through a single `Dispatcher`.
+
+| Crate | | |
+|---|---|---|
+| [`kbd-crossterm`](crates/kbd-crossterm) | [![crates.io](https://img.shields.io/crates/v/kbd-crossterm.svg)](https://crates.io/crates/kbd-crossterm) | [crossterm](https://docs.rs/crossterm) — TUI apps |
+| [`kbd-egui`](crates/kbd-egui) | [![crates.io](https://img.shields.io/crates/v/kbd-egui.svg)](https://crates.io/crates/kbd-egui) | [egui](https://docs.rs/egui) |
+| [`kbd-iced`](crates/kbd-iced) | [![crates.io](https://img.shields.io/crates/v/kbd-iced.svg)](https://crates.io/crates/kbd-iced) | [iced](https://docs.rs/iced) |
+| [`kbd-tao`](crates/kbd-tao) | [![crates.io](https://img.shields.io/crates/v/kbd-tao.svg)](https://crates.io/crates/kbd-tao) | [tao](https://docs.rs/tao) (Tauri) |
+| [`kbd-winit`](crates/kbd-winit) | [![crates.io](https://img.shields.io/crates/v/kbd-winit.svg)](https://crates.io/crates/kbd-winit) | [winit](https://docs.rs/winit) |
 
 ## Contributing
 

--- a/crates/kbd-crossterm/README.md
+++ b/crates/kbd-crossterm/README.md
@@ -5,6 +5,8 @@
 
 [`kbd`](https://crates.io/crates/kbd) bridge for [crossterm](https://docs.rs/crossterm) — converts key events and modifiers to `kbd` types.
 
+This lets you use `kbd`'s `Dispatcher`, hotkey parsing, layers, and sequences in a TUI app.
+
 Crossterm reports keys as characters (`Char('a')`) and modifier bitflags, while `kbd` uses physical key positions (`Key::A`) and typed `Modifier` values.
 
 ```toml

--- a/crates/kbd-crossterm/src/lib.rs
+++ b/crates/kbd-crossterm/src/lib.rs
@@ -2,7 +2,11 @@
 
 //! Crossterm key event conversions for `kbd`.
 //!
-//! This crate bridges crossterm's logical key model to `kbd`'s key types. Crossterm reports keys as characters (`Char('a')`) and modifier
+//! This crate converts crossterm's key events into `kbd`'s unified types
+//! so you can use `kbd`'s [`Dispatcher`](kbd::dispatcher::Dispatcher),
+//! hotkey parsing, layers, and sequences in a TUI app.
+//!
+//! Crossterm reports keys as characters (`Char('a')`) and modifier
 //! bitflags, while `kbd` uses physical key positions (`Key::A`) and
 //! typed `Modifier` values.
 //!

--- a/crates/kbd-egui/README.md
+++ b/crates/kbd-egui/README.md
@@ -5,6 +5,8 @@
 
 [`kbd`](https://crates.io/crates/kbd) bridge for [egui](https://docs.rs/egui) — converts key events and modifiers to `kbd` types.
 
+This lets GUI key events (from egui) and global hotkey events (from [`kbd-global`](https://docs.rs/kbd-global)) feed into the same `Dispatcher`. Useful in egui apps that want both in-window shortcuts and system-wide hotkeys handled through a single hotkey registry.
+
 Egui has a smaller, custom key enum that is not 1:1 with the W3C specification — some egui keys are logical/shifted characters without a single physical key equivalent (e.g., `Colon`, `Pipe`, `Plus`), and those return `None`.
 
 ```toml

--- a/crates/kbd-egui/src/lib.rs
+++ b/crates/kbd-egui/src/lib.rs
@@ -2,7 +2,13 @@
 
 //! Egui key event conversions for `kbd`.
 //!
-//! This crate bridges egui's key types to `kbd`'s key types.
+//! This crate converts egui's key events into `kbd`'s unified types so
+//! that GUI key events (from egui) and global hotkey events (from
+//! [`kbd-global`](https://docs.rs/kbd-global)) can feed into the same
+//! [`Dispatcher`](kbd::dispatcher::Dispatcher). This is useful in egui
+//! apps that want both in-window shortcuts and system-wide hotkeys
+//! handled through a single hotkey registry.
+//!
 //! Egui has a smaller, custom key enum that is not 1:1 with the W3C
 //! specification — some physical keys have no egui equivalent, some egui
 //! keys are logical/shifted characters without a single physical key

--- a/crates/kbd-iced/README.md
+++ b/crates/kbd-iced/README.md
@@ -5,6 +5,8 @@
 
 [`kbd`](https://crates.io/crates/kbd) bridge for [iced](https://docs.rs/iced) — converts key events and modifiers to `kbd` types.
 
+This lets GUI key events (from iced) and global hotkey events (from [`kbd-global`](https://docs.rs/kbd-global)) feed into the same `Dispatcher`. Useful in iced apps that want both in-window shortcuts and system-wide hotkeys handled through a single hotkey registry.
+
 Iced defines its own W3C-derived key types: `key::Code` for physical key positions and `key::Physical` wrapping `Code` with an unidentified fallback. This crate only converts physical keys — they are layout-independent and match `kbd`'s model.
 
 ```toml

--- a/crates/kbd-iced/src/lib.rs
+++ b/crates/kbd-iced/src/lib.rs
@@ -2,7 +2,13 @@
 
 //! Iced key event conversions for `kbd`.
 //!
-//! This crate bridges iced's keyboard types to `kbd`'s key types.
+//! This crate converts iced's keyboard events into `kbd`'s unified types
+//! so that GUI key events (from iced) and global hotkey events (from
+//! [`kbd-global`](https://docs.rs/kbd-global)) can feed into the same
+//! [`Dispatcher`](kbd::dispatcher::Dispatcher). This is useful in iced
+//! apps that want both in-window shortcuts and system-wide hotkeys
+//! handled through a single hotkey registry.
+//!
 //! iced defines its own W3C-derived key types: [`key::Code`] for physical
 //! key positions and [`key::Physical`] wrapping `Code` with an unidentified
 //! fallback. iced also has a logical key type for character/named key


### PR DESCRIPTION
## Changes

- **kbd-crossterm**: Explain it lets you use kbd's Dispatcher, layers, and sequences in a TUI app
- **kbd-egui**: Explain it lets GUI events and global hotkey events feed into the same Dispatcher
- **kbd-iced**: Same motivation as egui
- **Root README**: Split flat crates table into Core and Bridges sections, with a concrete example (kbd-tao + kbd-global for Tauri apps)

kbd-winit intentionally left out — will be tackled separately.