### PR TITLE
refactor: Add Modifier::collect_active and use across all bridge crates

### DIFF
--- a/crates/kbd-crossterm/src/lib.rs
+++ b/crates/kbd-crossterm/src/lib.rs
@@ -161,20 +161,12 @@ pub trait CrosstermModifiersExt: private::Sealed {
 
 impl CrosstermModifiersExt for KeyModifiers {
     fn to_modifiers(&self) -> Vec<Modifier> {
-        let mut modifiers = Vec::new();
-        if self.contains(KeyModifiers::CONTROL) {
-            modifiers.push(Modifier::Ctrl);
-        }
-        if self.contains(KeyModifiers::SHIFT) {
-            modifiers.push(Modifier::Shift);
-        }
-        if self.contains(KeyModifiers::ALT) {
-            modifiers.push(Modifier::Alt);
-        }
-        if self.contains(KeyModifiers::SUPER) {
-            modifiers.push(Modifier::Super);
-        }
-        modifiers
+        Modifier::collect_active([
+            (self.contains(KeyModifiers::CONTROL), Modifier::Ctrl),
+            (self.contains(KeyModifiers::SHIFT), Modifier::Shift),
+            (self.contains(KeyModifiers::ALT), Modifier::Alt),
+            (self.contains(KeyModifiers::SUPER), Modifier::Super),
+        ])
     }
 }
 

--- a/crates/kbd-egui/src/lib.rs
+++ b/crates/kbd-egui/src/lib.rs
@@ -280,16 +280,12 @@ pub trait EguiModifiersExt: private::Sealed {
 
 impl EguiModifiersExt for Modifiers {
     fn to_modifiers(&self) -> Vec<Modifier> {
-        [
+        Modifier::collect_active([
             (self.ctrl, Modifier::Ctrl),
             (self.shift, Modifier::Shift),
             (self.alt, Modifier::Alt),
             (self.mac_cmd, Modifier::Super),
-        ]
-        .into_iter()
-        .filter(|(active, _)| *active)
-        .map(|(_, m)| m)
-        .collect()
+        ])
     }
 }
 

--- a/crates/kbd-iced/src/lib.rs
+++ b/crates/kbd-iced/src/lib.rs
@@ -371,20 +371,12 @@ pub trait IcedModifiersExt: private::Sealed {
 
 impl IcedModifiersExt for Modifiers {
     fn to_modifiers(&self) -> Vec<Modifier> {
-        let mut modifiers = Vec::new();
-        if self.control() {
-            modifiers.push(Modifier::Ctrl);
-        }
-        if self.shift() {
-            modifiers.push(Modifier::Shift);
-        }
-        if self.alt() {
-            modifiers.push(Modifier::Alt);
-        }
-        if self.logo() {
-            modifiers.push(Modifier::Super);
-        }
-        modifiers
+        Modifier::collect_active([
+            (self.control(), Modifier::Ctrl),
+            (self.shift(), Modifier::Shift),
+            (self.alt(), Modifier::Alt),
+            (self.logo(), Modifier::Super),
+        ])
     }
 }
 

--- a/crates/kbd-tao/src/lib.rs
+++ b/crates/kbd-tao/src/lib.rs
@@ -384,20 +384,12 @@ pub trait TaoModifiersExt: private::Sealed {
 
 impl TaoModifiersExt for ModifiersState {
     fn to_modifiers(&self) -> Vec<Modifier> {
-        let mut modifiers = Vec::new();
-        if self.control_key() {
-            modifiers.push(Modifier::Ctrl);
-        }
-        if self.shift_key() {
-            modifiers.push(Modifier::Shift);
-        }
-        if self.alt_key() {
-            modifiers.push(Modifier::Alt);
-        }
-        if self.super_key() {
-            modifiers.push(Modifier::Super);
-        }
-        modifiers
+        Modifier::collect_active([
+            (self.control_key(), Modifier::Ctrl),
+            (self.shift_key(), Modifier::Shift),
+            (self.alt_key(), Modifier::Alt),
+            (self.super_key(), Modifier::Super),
+        ])
     }
 }
 

--- a/crates/kbd-winit/src/lib.rs
+++ b/crates/kbd-winit/src/lib.rs
@@ -419,20 +419,12 @@ pub trait WinitModifiersExt: private::Sealed {
 
 impl WinitModifiersExt for ModifiersState {
     fn to_modifiers(&self) -> Vec<Modifier> {
-        let mut modifiers = Vec::new();
-        if self.control_key() {
-            modifiers.push(Modifier::Ctrl);
-        }
-        if self.shift_key() {
-            modifiers.push(Modifier::Shift);
-        }
-        if self.alt_key() {
-            modifiers.push(Modifier::Alt);
-        }
-        if self.super_key() {
-            modifiers.push(Modifier::Super);
-        }
-        modifiers
+        Modifier::collect_active([
+            (self.control_key(), Modifier::Ctrl),
+            (self.shift_key(), Modifier::Shift),
+            (self.alt_key(), Modifier::Alt),
+            (self.super_key(), Modifier::Super),
+        ])
     }
 }
 

--- a/crates/kbd/src/hotkey.rs
+++ b/crates/kbd/src/hotkey.rs
@@ -77,6 +77,36 @@ impl Modifier {
             Self::Super => (Key::META_LEFT, Key::META_RIGHT),
         }
     }
+
+    /// Collect active modifiers from a list of `(flag, modifier)` pairs.
+    ///
+    /// Bridge crates all perform the same conversion: check each
+    /// framework-specific modifier flag and collect the active ones into
+    /// a `Vec<Modifier>`. This helper centralizes that logic.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use kbd::hotkey::Modifier;
+    ///
+    /// let modifiers = Modifier::collect_active([
+    ///     (true, Modifier::Ctrl),
+    ///     (true, Modifier::Shift),
+    ///     (false, Modifier::Alt),
+    ///     (false, Modifier::Super),
+    /// ]);
+    /// assert_eq!(modifiers, vec![Modifier::Ctrl, Modifier::Shift]);
+    /// ```
+    #[must_use]
+    pub fn collect_active<const N: usize>(flags: [(bool, Modifier); N]) -> Vec<Modifier> {
+        let mut modifiers = Vec::with_capacity(N);
+        for (active, modifier) in flags {
+            if active {
+                modifiers.push(modifier);
+            }
+        }
+        modifiers
+    }
 }
 
 impl fmt::Display for Modifier {
@@ -361,6 +391,59 @@ mod tests {
         let hotkey = "Ctrl+Shift".parse::<Hotkey>().unwrap();
         assert_eq!(hotkey.key(), Key::SHIFT_LEFT);
         assert_eq!(hotkey.modifiers(), &[Modifier::Ctrl]);
+    }
+
+    #[test]
+    fn collect_active_returns_only_active_modifiers() {
+        let modifiers = Modifier::collect_active([
+            (true, Modifier::Ctrl),
+            (false, Modifier::Shift),
+            (true, Modifier::Alt),
+            (false, Modifier::Super),
+        ]);
+        assert_eq!(modifiers, vec![Modifier::Ctrl, Modifier::Alt]);
+    }
+
+    #[test]
+    fn collect_active_all_true() {
+        let modifiers = Modifier::collect_active([
+            (true, Modifier::Ctrl),
+            (true, Modifier::Shift),
+            (true, Modifier::Alt),
+            (true, Modifier::Super),
+        ]);
+        assert_eq!(
+            modifiers,
+            vec![
+                Modifier::Ctrl,
+                Modifier::Shift,
+                Modifier::Alt,
+                Modifier::Super,
+            ]
+        );
+    }
+
+    #[test]
+    fn collect_active_none_true() {
+        let modifiers = Modifier::collect_active([
+            (false, Modifier::Ctrl),
+            (false, Modifier::Shift),
+            (false, Modifier::Alt),
+            (false, Modifier::Super),
+        ]);
+        assert!(modifiers.is_empty());
+    }
+
+    #[test]
+    fn collect_active_single() {
+        let modifiers = Modifier::collect_active([(true, Modifier::Shift)]);
+        assert_eq!(modifiers, vec![Modifier::Shift]);
+    }
+
+    #[test]
+    fn collect_active_empty_array() {
+        let modifiers = Modifier::collect_active([]);
+        assert!(modifiers.is_empty());
     }
 
     #[test]

--- a/crates/kbd/tests/public_api.rs
+++ b/crates/kbd/tests/public_api.rs
@@ -555,6 +555,32 @@ fn topmost_layer_wins() {
     assert_eq!(layer1_counter.load(Ordering::Relaxed), 0);
 }
 
+// Modifier::collect_active builds modifiers that dispatch correctly
+#[test]
+fn collect_active_builds_dispatchable_hotkey() {
+    let mut dispatcher = Dispatcher::new();
+    dispatcher
+        .register(
+            Hotkey::new(Key::S)
+                .modifier(Modifier::Ctrl)
+                .modifier(Modifier::Shift),
+            Action::Suppress,
+        )
+        .unwrap();
+
+    // Simulate what a bridge crate does: collect framework flags into modifiers
+    let mods = Modifier::collect_active([
+        (true, Modifier::Ctrl),
+        (true, Modifier::Shift),
+        (false, Modifier::Alt),
+        (false, Modifier::Super),
+    ]);
+    let hotkey = Hotkey::with_modifiers(Key::S, mods);
+
+    let result = dispatcher.process(&hotkey, KeyTransition::Press);
+    assert!(matches!(result, MatchResult::Matched { .. }));
+}
+
 // register_binding duplicate returns error
 #[test]
 fn register_binding_duplicate_returns_error() {


### PR DESCRIPTION
## Summary

All 5 bridge crates had duplicated logic for converting framework-specific modifier flags into `Vec<Modifier>`. This extracts that into a single `Modifier::collect_active()` helper in kbd core.

## Problem

Each bridge crate had its own version of the same pattern — either imperative push-to-empty-Vec or iterator-filter-collect. Both allocated a Vec without knowing the final size upfront.

## Solution

`Modifier::collect_active()` takes a const-generic `[(bool, Modifier); N]` array and returns a `Vec<Modifier>` with `Vec::with_capacity(N)` — one allocation, exact upper bound, no reallocs.

Bridge crates now call:
```rust
Modifier::collect_active([
    (self.control_key(), Modifier::Ctrl),
    (self.shift_key(), Modifier::Shift),
    (self.alt_key(), Modifier::Alt),
    (self.super_key(), Modifier::Super),
])
```

## Changed crates

- **kbd** — added `Modifier::collect_active()` with `#[must_use]`, doc example, 5 unit tests, 1 integration test
- **kbd-crossterm** — switched to `collect_active`
- **kbd-egui** — switched to `collect_active`
- **kbd-iced** — switched to `collect_active`
- **kbd-tao** — switched to `collect_active`
- **kbd-winit** — switched to `collect_active`

## Tests

- 5 unit tests: mixed flags, all true, none true, single element, empty array
- 1 integration test: builds a hotkey via `collect_active` and dispatches it
- 1 doctest on the method
- Full workspace test suite passes ✅
- Clippy clean ✅