### PR TITLE
feat(kbd): Implement serde feature for kbd types

### DIFF
--- a/crates/kbd/Cargo.toml
+++ b/crates/kbd/Cargo.toml
@@ -19,6 +19,9 @@ keyboard-types = { workspace = true }
 serde = { workspace = true, optional = true }
 thiserror = { workspace = true }
 
+[dev-dependencies]
+serde_json = { workspace = true }
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/kbd/src/binding.rs
+++ b/crates/kbd/src/binding.rs
@@ -15,6 +15,8 @@ use crate::hotkey::Hotkey;
 
 /// Unique identifier for a registered binding.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct BindingId(u64);
 
 impl BindingId {
@@ -59,6 +61,7 @@ impl Default for BindingId {
 /// assert_eq!(binding.propagation(), KeyPropagation::Continue);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub enum KeyPropagation {
     /// Stop propagation — the event is consumed and not forwarded.
@@ -89,6 +92,7 @@ pub enum KeyPropagation {
 /// assert_eq!(opts.overlay_visibility(), OverlayVisibility::Visible);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub enum OverlayVisibility {
     /// Binding is shown in overlays and help screens.
@@ -117,6 +121,7 @@ pub enum OverlayVisibility {
 /// assert_eq!(opts.propagation(), KeyPropagation::Stop);
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BindingOptions {
     propagation: KeyPropagation,
     /// Human-readable label for this binding ("Copy to clipboard").

--- a/crates/kbd/src/hotkey.rs
+++ b/crates/kbd/src/hotkey.rs
@@ -29,6 +29,7 @@ use crate::key::Key;
 /// Left and right physical variants are canonicalized — both `ControlLeft`
 /// and `ControlRight` map to `Modifier::Ctrl`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Modifier {
     /// The Control modifier (left or right).
     Ctrl,
@@ -284,6 +285,21 @@ impl fmt::Display for Hotkey {
     }
 }
 
+#[cfg(feature = "serde")]
+impl serde::Serialize for Hotkey {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(self)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Hotkey {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = <&str>::deserialize(deserializer)?;
+        s.parse().map_err(serde::de::Error::custom)
+    }
+}
+
 /// A multi-step hotkey sequence like `"Ctrl+K, Ctrl+C"`.
 ///
 /// Sequences are comma-separated hotkeys. Each step must be pressed
@@ -344,6 +360,21 @@ impl fmt::Display for HotkeySequence {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for HotkeySequence {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(self)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for HotkeySequence {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = <&str>::deserialize(deserializer)?;
+        s.parse().map_err(serde::de::Error::custom)
     }
 }
 

--- a/crates/kbd/src/key.rs
+++ b/crates/kbd/src/key.rs
@@ -399,6 +399,21 @@ impl From<Key> for Code {
     }
 }
 
+#[cfg(feature = "serde")]
+impl serde::Serialize for Key {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Key {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = <&str>::deserialize(deserializer)?;
+        s.parse().map_err(serde::de::Error::custom)
+    }
+}
+
 impl fmt::Display for Key {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())

--- a/crates/kbd/src/key_state.rs
+++ b/crates/kbd/src/key_state.rs
@@ -15,6 +15,7 @@ use crate::key::Key;
 
 /// Whether a key was pressed, released, or repeated.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub enum KeyTransition {
     /// The key was pressed down.

--- a/crates/kbd/src/layer.rs
+++ b/crates/kbd/src/layer.rs
@@ -26,6 +26,8 @@ use crate::hotkey::Hotkey;
 ///
 /// Converts from `&str` and `String` for convenience.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct LayerName(Box<str>);
 
 impl LayerName {
@@ -84,6 +86,7 @@ impl std::fmt::Display for LayerName {
 /// assert_eq!(modal.options().unmatched(), UnmatchedKeys::Swallow);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub enum UnmatchedKeys {
     /// Unmatched keys pass to the next layer down the stack.
@@ -95,6 +98,7 @@ pub enum UnmatchedKeys {
 
 /// Per-layer behavioral options.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LayerOptions {
     /// If set, automatically pop the layer after this many keypresses.
     oneshot: Option<usize>,

--- a/crates/kbd/tests/serde.rs
+++ b/crates/kbd/tests/serde.rs
@@ -1,0 +1,214 @@
+//! Serde round-trip tests for kbd types.
+//!
+//! These verify that all serde-enabled types serialize and deserialize
+//! correctly through JSON. Types with string-based serde (`Key`, `Hotkey`,
+//! `HotkeySequence`) use their `Display`/`FromStr` representations.
+
+#![cfg(feature = "serde")]
+
+use kbd::binding::BindingId;
+use kbd::binding::BindingOptions;
+use kbd::binding::KeyPropagation;
+use kbd::binding::OverlayVisibility;
+use kbd::hotkey::Hotkey;
+use kbd::hotkey::HotkeySequence;
+use kbd::hotkey::Modifier;
+use kbd::key::Key;
+use kbd::key_state::KeyTransition;
+use kbd::layer::LayerName;
+use kbd::layer::LayerOptions;
+use kbd::layer::UnmatchedKeys;
+
+fn round_trip<T>(value: &T) -> T
+where
+    T: serde::Serialize + serde::de::DeserializeOwned + std::fmt::Debug,
+{
+    let json = serde_json::to_string(value).expect("serialize");
+    serde_json::from_str(&json).expect("deserialize")
+}
+
+// Key
+
+#[test]
+fn key_serializes_as_human_readable_string() {
+    let json = serde_json::to_string(&Key::A).unwrap();
+    assert_eq!(json, r#""A""#);
+}
+
+#[test]
+fn key_deserializes_from_human_readable_string() {
+    let key: Key = serde_json::from_str(r#""A""#).unwrap();
+    assert_eq!(key, Key::A);
+}
+
+#[test]
+fn key_round_trip() {
+    let keys = [
+        Key::A,
+        Key::ENTER,
+        Key::SPACE,
+        Key::F12,
+        Key::ARROW_UP,
+        Key::CONTROL_LEFT,
+        Key::ESCAPE,
+    ];
+    for key in &keys {
+        assert_eq!(&round_trip(key), key, "round-trip failed for {key:?}");
+    }
+}
+
+#[test]
+fn key_accepts_aliases() {
+    // "Enter" and "Return" both parse to the same key
+    let enter: Key = serde_json::from_str(r#""Enter""#).unwrap();
+    let ret: Key = serde_json::from_str(r#""Return""#).unwrap();
+    assert_eq!(enter, ret);
+}
+
+// Modifier
+
+#[test]
+fn modifier_round_trip() {
+    for modifier in [
+        Modifier::Ctrl,
+        Modifier::Shift,
+        Modifier::Alt,
+        Modifier::Super,
+    ] {
+        assert_eq!(
+            round_trip(&modifier),
+            modifier,
+            "round-trip failed for {modifier:?}"
+        );
+    }
+}
+
+// Hotkey
+
+#[test]
+fn hotkey_serializes_as_string() {
+    let hotkey = Hotkey::new(Key::A)
+        .modifier(Modifier::Ctrl)
+        .modifier(Modifier::Shift);
+    let json = serde_json::to_string(&hotkey).unwrap();
+    assert_eq!(json, r#""Ctrl+Shift+A""#);
+}
+
+#[test]
+fn hotkey_deserializes_from_string() {
+    let hotkey: Hotkey = serde_json::from_str(r#""Ctrl+A""#).unwrap();
+    assert_eq!(hotkey.key(), Key::A);
+    assert_eq!(hotkey.modifiers(), &[Modifier::Ctrl]);
+}
+
+#[test]
+fn hotkey_round_trip() {
+    let hotkeys = [
+        Hotkey::new(Key::A),
+        Hotkey::new(Key::S).modifier(Modifier::Ctrl),
+        Hotkey::new(Key::F5)
+            .modifier(Modifier::Ctrl)
+            .modifier(Modifier::Shift),
+        Hotkey::new(Key::ESCAPE),
+    ];
+    for hotkey in &hotkeys {
+        assert_eq!(
+            &round_trip(hotkey),
+            hotkey,
+            "round-trip failed for {hotkey}"
+        );
+    }
+}
+
+// HotkeySequence
+
+#[test]
+fn hotkey_sequence_serializes_as_string() {
+    let seq: HotkeySequence = "Ctrl+K, Ctrl+C".parse().unwrap();
+    let json = serde_json::to_string(&seq).unwrap();
+    assert_eq!(json, r#""Ctrl+K, Ctrl+C""#);
+}
+
+#[test]
+fn hotkey_sequence_round_trip() {
+    let seq: HotkeySequence = "Ctrl+K, Ctrl+C".parse().unwrap();
+    assert_eq!(round_trip(&seq), seq);
+}
+
+// LayerName
+
+#[test]
+fn layer_name_serializes_as_string() {
+    let name = LayerName::new("nav");
+    let json = serde_json::to_string(&name).unwrap();
+    assert_eq!(json, r#""nav""#);
+}
+
+#[test]
+fn layer_name_round_trip() {
+    let name = LayerName::new("navigation");
+    assert_eq!(round_trip(&name), name);
+}
+
+// Simple enums
+
+#[test]
+fn key_transition_round_trip() {
+    for variant in [
+        KeyTransition::Press,
+        KeyTransition::Release,
+        KeyTransition::Repeat,
+    ] {
+        assert_eq!(round_trip(&variant), variant);
+    }
+}
+
+#[test]
+fn unmatched_keys_round_trip() {
+    for variant in [UnmatchedKeys::Fallthrough, UnmatchedKeys::Swallow] {
+        assert_eq!(round_trip(&variant), variant);
+    }
+}
+
+#[test]
+fn key_propagation_round_trip() {
+    for variant in [KeyPropagation::Stop, KeyPropagation::Continue] {
+        assert_eq!(round_trip(&variant), variant);
+    }
+}
+
+#[test]
+fn overlay_visibility_round_trip() {
+    for variant in [OverlayVisibility::Visible, OverlayVisibility::Hidden] {
+        assert_eq!(round_trip(&variant), variant);
+    }
+}
+
+// Composite types
+
+#[test]
+fn binding_options_round_trip() {
+    let opts = BindingOptions::default()
+        .with_description("Copy to clipboard")
+        .with_propagation(KeyPropagation::Continue)
+        .with_overlay_visibility(OverlayVisibility::Hidden);
+    assert_eq!(round_trip(&opts), opts);
+}
+
+#[test]
+fn binding_options_default_round_trip() {
+    let opts = BindingOptions::default();
+    assert_eq!(round_trip(&opts), opts);
+}
+
+#[test]
+fn layer_options_round_trip() {
+    let opts = LayerOptions::default().with_unmatched(UnmatchedKeys::Swallow);
+    assert_eq!(round_trip(&opts), opts);
+}
+
+#[test]
+fn binding_id_round_trip() {
+    let id = BindingId::new();
+    assert_eq!(round_trip(&id), id);
+}


### PR DESCRIPTION
The `serde` feature was declared and documented in the kbd crate but had no actual implementations. This adds `Serialize`/`Deserialize` to all public data types, fulfilling the documented contract before the initial crates.io publish.

## Approach

**String-based serde** (using `Display`/`FromStr`) for config-file-friendly types:
- `Key` → `"A"`, `"Enter"`, `"F12"`
- `Hotkey` → `"Ctrl+Shift+A"`
- `HotkeySequence` → `"Ctrl+K, Ctrl+C"`

**Derive-based serde** for everything else:
- Simple enums: `Modifier`, `KeyTransition`, `UnmatchedKeys`, `KeyPropagation`, `OverlayVisibility`
- Transparent newtypes: `LayerName`, `BindingId`
- Structs: `BindingOptions`, `LayerOptions`

**Skipped** (not serializable): `Action` (contains `Box<dyn Fn()>`), `Layer`, `RegisteredBinding`.

## Tests

20 new round-trip tests in `crates/kbd/tests/serde.rs` covering all types.