### PR TITLE
Document and todo!() unimplemented emit action variants

### DIFF
--- a/crates/kbd-global/src/engine.rs
+++ b/crates/kbd-global/src/engine.rs
@@ -351,21 +351,37 @@ impl Engine {
     }
 }
 
-/// Execute a callback action with panic isolation — a panicking callback
+/// Execute a user-facing action with panic isolation — a panicking callback
 /// never kills the engine thread.
 ///
-/// Only handles `Action::Callback`. Layer-control actions (`PushLayer`,
-/// `PopLayer`, `ToggleLayer`) are handled by `Dispatcher::process()` internally.
+/// Handles `Action::Callback` directly. Layer-control actions (`PushLayer`,
+/// `PopLayer`, `ToggleLayer`) are handled by `Dispatcher::process()` internally
+/// and never reach this function. `Action::Suppress` is a no-op by design.
+///
+/// `Action::EmitHotkey` and `Action::EmitSequence` are not yet implemented —
+/// they will panic if reached. Key emission support is planned.
 fn execute_action(action: &Action) {
-    if let Action::Callback(callback) = action
-        && let Err(panic) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            callback();
-        }))
-    {
-        tracing::error!(
-            panic_info = format!("{panic:?}"),
-            "user callback panicked — panic caught, engine continues"
-        );
+    match action {
+        Action::Callback(callback) => {
+            if let Err(panic) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                callback();
+            })) {
+                tracing::error!(
+                    panic_info = format!("{panic:?}"),
+                    "user callback panicked — panic caught, engine continues"
+                );
+            }
+        }
+        Action::EmitHotkey(_) => {
+            todo!("Action::EmitHotkey is not yet implemented in the kbd-global runtime")
+        }
+        Action::EmitSequence(_) => {
+            todo!("Action::EmitSequence is not yet implemented in the kbd-global runtime")
+        }
+        // Layer actions (PushLayer, PopLayer, ToggleLayer) are handled by
+        // Dispatcher::process(). Suppress is a no-op by design. Future
+        // variants from #[non_exhaustive] are also no-ops until implemented.
+        _ => {}
     }
 }
 

--- a/crates/kbd/src/action.rs
+++ b/crates/kbd/src/action.rs
@@ -6,8 +6,8 @@
 //! # Variants
 //!
 //! - `Callback` — run user code
-//! - `EmitHotkey` — emit a different key through uinput (requires grab)
-//! - `EmitSequence` — emit a series of keys (requires grab)
+//! - `EmitHotkey` — emit a different key through uinput (not yet implemented)
+//! - `EmitSequence` — emit a series of keys (not yet implemented)
 //! - `PushLayer` / `PopLayer` / `ToggleLayer` — layer stack control
 //! - `Suppress` — explicitly consume the key, do nothing
 
@@ -23,8 +23,18 @@ pub enum Action {
     /// Execute user callback code.
     Callback(Box<dyn Fn() + Send + Sync + 'static>),
     /// Emit a single key (with optional modifiers) through the virtual device.
+    ///
+    /// **Not yet implemented in `kbd-global`'s runtime.** The variant exists
+    /// for forward compatibility — key emission support is planned. Using this
+    /// variant with [`kbd-global`](https://docs.rs/kbd-global) will currently
+    /// panic at runtime.
     EmitHotkey(Hotkey),
     /// Emit a sequence of hotkeys.
+    ///
+    /// **Not yet implemented in `kbd-global`'s runtime.** The variant exists
+    /// for forward compatibility — key emission support is planned. Using this
+    /// variant with [`kbd-global`](https://docs.rs/kbd-global) will currently
+    /// panic at runtime.
     EmitSequence(HotkeySequence),
     /// Push a named layer onto the stack.
     PushLayer(LayerName),


### PR DESCRIPTION
`Action::EmitHotkey` and `Action::EmitSequence` exist in the `Action` enum for forward compatibility (Phase 5 in the plan) but aren't implemented in `kbd-global`'s runtime yet. Previously they were **silently ignored** — a user could register an `EmitHotkey` action and nothing would happen with no indication why.

## Changes

- **`crates/kbd/src/action.rs`**: Added doc comments on both variants clearly stating they're not yet implemented and will panic at runtime if used with `kbd-global`
- **`crates/kbd-global/src/engine.rs`**: Replaced the silent no-op `if let` with an explicit `match` that calls `todo!()` for emit variants, making the failure loud and obvious instead of silent