### PR TITLE
ci: add semver checks workflow for PRs

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -42,7 +42,6 @@ jobs:
       - name: Run semver checks
         id: semver
         env:
-          NO_COLOR: 1
           BASE_REF: ${{ github.base_ref }}
         run: |
           if cargo semver-checks check-release \


### PR DESCRIPTION
Adds an informational cargo-semver-checks workflow that runs on PRs targeting main. Posts a sticky PR comment showing whether the PR introduces breaking API changes, with full details in a collapsible section. Never fails the PR -- purely informational.