### PR TITLE
ci: use independent versioning for workspace crates

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -7,42 +7,34 @@ publish_allow_dirty = false
 
 [[package]]
 name = "kbd"
-version_group = "kbd"
 changelog_path = "CHANGELOG.md"
 
 [[package]]
 name = "kbd-crossterm"
-version_group = "kbd"
 changelog_path = "CHANGELOG.md"
 
 [[package]]
 name = "kbd-egui"
-version_group = "kbd"
 changelog_path = "CHANGELOG.md"
 
 [[package]]
 name = "kbd-evdev"
-version_group = "kbd"
 changelog_path = "CHANGELOG.md"
 
 [[package]]
 name = "kbd-global"
-version_group = "kbd"
 changelog_path = "CHANGELOG.md"
 
 [[package]]
 name = "kbd-iced"
-version_group = "kbd"
 changelog_path = "CHANGELOG.md"
 
 [[package]]
 name = "kbd-tao"
-version_group = "kbd"
 changelog_path = "CHANGELOG.md"
 
 [[package]]
 name = "kbd-winit"
-version_group = "kbd"
 changelog_path = "CHANGELOG.md"
 
 # excluded from releases


### PR DESCRIPTION
Remove version_group from release-plz config so each crate is versioned independently based on its own changes. release-plz will still bump dependents automatically when their dependencies update.