### PR TITLE
chore(kbd): Extract registration/storage helpers into dispatcher/registry.rs

### DIFF
--- a/crates/kbd/src/dispatcher.rs
+++ b/crates/kbd/src/dispatcher.rs
@@ -10,6 +10,7 @@
 
 mod layers;
 mod query;
+mod registry;
 mod sequence;
 mod timeout;
 
@@ -36,8 +37,6 @@ use crate::layer::LayerName;
 use crate::layer::StoredLayer;
 use crate::layer::UnmatchedKeys;
 use crate::sequence::PendingSequenceInfo;
-use crate::sequence::SequenceInput;
-use crate::sequence::SequenceOptions;
 
 /// Result of attempting to match a key event against registered bindings.
 #[derive(Debug)]
@@ -189,158 +188,10 @@ impl Dispatcher {
         Self::default()
     }
 
-    /// Register a binding. Returns the assigned [`BindingId`].
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::AlreadyRegistered`](crate::error::Error::AlreadyRegistered)
-    /// if a binding for the same hotkey exists.
-    pub fn register(
-        &mut self,
-        hotkey: impl Into<Hotkey>,
-        action: impl Into<Action>,
-    ) -> Result<BindingId, crate::error::Error> {
-        let id = BindingId::new();
-        let binding = RegisteredBinding::new(id, hotkey.into(), action.into());
-        self.register_binding(binding)?;
-        Ok(id)
-    }
-
-    /// Register a multi-step sequence binding with default sequence options.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Parse`](crate::error::Error::Parse) when sequence input
-    /// conversion fails, or
-    /// [`Error::AlreadyRegistered`](crate::error::Error::AlreadyRegistered)
-    /// if a binding for the same sequence already exists.
-    pub fn register_sequence(
-        &mut self,
-        sequence: impl SequenceInput,
-        action: impl Into<Action>,
-    ) -> Result<BindingId, crate::error::Error> {
-        self.register_sequence_with_options(sequence, action, SequenceOptions::default())
-    }
-
-    /// Register a sequence with explicit sequence options.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Parse`](crate::error::Error::Parse) when sequence input
-    /// conversion fails, or
-    /// [`Error::AlreadyRegistered`](crate::error::Error::AlreadyRegistered)
-    /// if a binding for the same sequence already exists.
-    pub fn register_sequence_with_options(
-        &mut self,
-        sequence: impl SequenceInput,
-        action: impl Into<Action>,
-        options: SequenceOptions,
-    ) -> Result<BindingId, crate::error::Error> {
-        let id = BindingId::new();
-        let sequence = sequence.into_sequence()?;
-        self.register_sequence_binding_with_id(id, sequence, action.into(), options)?;
-        Ok(id)
-    }
-
-    /// Register a sequence binding with a caller-provided binding ID.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::AlreadyRegistered`](crate::error::Error::AlreadyRegistered)
-    /// if a binding for the same sequence already exists.
-    pub(crate) fn register_sequence_binding_with_id(
-        &mut self,
-        id: BindingId,
-        sequence: HotkeySequence,
-        action: Action,
-        options: SequenceOptions,
-    ) -> Result<(), crate::error::Error> {
-        let binding = RegisteredSequenceBinding::new(id, sequence, action, options);
-        self.register_sequence_binding(binding)
-    }
-
     /// Return current in-progress sequence state, if any.
     #[must_use]
     pub fn pending_sequence(&self) -> Option<PendingSequenceInfo> {
         self.pending_sequence_snapshot()
-    }
-
-    /// Register a [`RegisteredBinding`] with full options control.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::AlreadyRegistered`](crate::error::Error::AlreadyRegistered)
-    /// if a binding for the same hotkey exists.
-    pub fn register_binding(
-        &mut self,
-        binding: RegisteredBinding,
-    ) -> Result<(), crate::error::Error> {
-        let id = binding.id();
-        let hotkey = binding.hotkey().clone();
-
-        if self.bindings_by_id.contains_key(&id)
-            || self.sequence_bindings_by_id.contains_key(&id)
-            || self.binding_ids_by_hotkey.contains_key(&hotkey)
-        {
-            return Err(crate::error::Error::AlreadyRegistered);
-        }
-
-        self.binding_ids_by_hotkey.insert(hotkey, id);
-        self.bindings_by_id.insert(id, binding);
-        Ok(())
-    }
-
-    fn register_sequence_binding(
-        &mut self,
-        binding: RegisteredSequenceBinding,
-    ) -> Result<(), crate::error::Error> {
-        let id = binding.id;
-        let sequence = binding.sequence.clone();
-
-        if self.sequence_bindings_by_id.contains_key(&id)
-            || self.bindings_by_id.contains_key(&id)
-            || self.sequence_ids_by_value.contains_key(&sequence)
-        {
-            return Err(crate::error::Error::AlreadyRegistered);
-        }
-
-        self.sequence_ids_by_value.insert(sequence, id);
-        self.sequence_bindings_by_id.insert(id, binding);
-        Ok(())
-    }
-
-    /// Unregister a binding by its [`BindingId`].
-    pub fn unregister(&mut self, id: BindingId) {
-        if let Some(binding) = self.bindings_by_id.remove(&id) {
-            self.binding_ids_by_hotkey.remove(binding.hotkey());
-        }
-
-        if let Some(binding) = self.sequence_bindings_by_id.remove(&id) {
-            self.sequence_ids_by_value.remove(&binding.sequence);
-        }
-
-        self.active_sequences
-            .retain(|active| !matches!(active.binding_ref, SequenceBindingRef::Global(global_id) if global_id == id));
-
-        if self.pending_standalone.as_ref().is_some_and(|pending| {
-            matches!(
-                pending.binding_ref,
-                MatchedBindingRef::Global(global_id) | MatchedBindingRef::SequenceGlobal(global_id)
-                    if global_id == id
-            )
-        }) {
-            self.pending_standalone = None;
-        }
-
-        if self.active_sequences.is_empty() {
-            self.pending_standalone = None;
-        }
-    }
-
-    /// Check whether a hotkey has a registered global binding.
-    #[must_use]
-    pub fn is_registered(&self, hotkey: &Hotkey) -> bool {
-        self.binding_ids_by_hotkey.contains_key(hotkey)
     }
 
     /// Define a named layer. The layer is not active until pushed.
@@ -626,30 +477,6 @@ mod tests {
     use super::*;
     use crate::key::Key;
     use crate::layer::Layer;
-
-    #[test]
-    fn register_returns_unique_id() {
-        let mut dispatcher = Dispatcher::new();
-        let id1 = dispatcher
-            .register(Hotkey::new(Key::A), Action::Suppress)
-            .unwrap();
-        let id2 = dispatcher
-            .register(Hotkey::new(Key::B), Action::Suppress)
-            .unwrap();
-        assert_ne!(id1, id2);
-    }
-
-    #[test]
-    fn is_registered_reflects_state() {
-        let mut dispatcher = Dispatcher::new();
-        let hotkey = Hotkey::new(Key::C).modifier(Modifier::Ctrl);
-        assert!(!dispatcher.is_registered(&hotkey));
-
-        dispatcher
-            .register(hotkey.clone(), Action::Suppress)
-            .unwrap();
-        assert!(dispatcher.is_registered(&hotkey));
-    }
 
     #[test]
     fn process_requires_exact_modifiers() {

--- a/crates/kbd/src/dispatcher/registry.rs
+++ b/crates/kbd/src/dispatcher/registry.rs
@@ -1,0 +1,302 @@
+use super::Dispatcher;
+use super::MatchedBindingRef;
+use super::sequence::RegisteredSequenceBinding;
+use super::sequence::SequenceBindingRef;
+use crate::action::Action;
+use crate::binding::BindingId;
+use crate::binding::RegisteredBinding;
+use crate::hotkey::Hotkey;
+use crate::hotkey::HotkeySequence;
+use crate::sequence::SequenceInput;
+use crate::sequence::SequenceOptions;
+
+impl Dispatcher {
+    /// Register a binding. Returns the assigned [`BindingId`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::AlreadyRegistered`](crate::error::Error::AlreadyRegistered)
+    /// if a binding for the same hotkey exists.
+    pub fn register(
+        &mut self,
+        hotkey: impl Into<Hotkey>,
+        action: impl Into<Action>,
+    ) -> Result<BindingId, crate::error::Error> {
+        let id = BindingId::new();
+        let binding = RegisteredBinding::new(id, hotkey.into(), action.into());
+        self.register_binding(binding)?;
+        Ok(id)
+    }
+
+    /// Register a multi-step sequence binding with default sequence options.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Parse`](crate::error::Error::Parse) when sequence input
+    /// conversion fails, or
+    /// [`Error::AlreadyRegistered`](crate::error::Error::AlreadyRegistered)
+    /// if a binding for the same sequence already exists.
+    pub fn register_sequence(
+        &mut self,
+        sequence: impl SequenceInput,
+        action: impl Into<Action>,
+    ) -> Result<BindingId, crate::error::Error> {
+        self.register_sequence_with_options(sequence, action, SequenceOptions::default())
+    }
+
+    /// Register a sequence with explicit sequence options.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Parse`](crate::error::Error::Parse) when sequence input
+    /// conversion fails, or
+    /// [`Error::AlreadyRegistered`](crate::error::Error::AlreadyRegistered)
+    /// if a binding for the same sequence already exists.
+    pub fn register_sequence_with_options(
+        &mut self,
+        sequence: impl SequenceInput,
+        action: impl Into<Action>,
+        options: SequenceOptions,
+    ) -> Result<BindingId, crate::error::Error> {
+        let id = BindingId::new();
+        let sequence = sequence.into_sequence()?;
+        self.register_sequence_binding_with_id(id, sequence, action.into(), options)?;
+        Ok(id)
+    }
+
+    /// Register a sequence binding with a caller-provided binding ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::AlreadyRegistered`](crate::error::Error::AlreadyRegistered)
+    /// if a binding for the same sequence already exists.
+    pub(crate) fn register_sequence_binding_with_id(
+        &mut self,
+        id: BindingId,
+        sequence: HotkeySequence,
+        action: Action,
+        options: SequenceOptions,
+    ) -> Result<(), crate::error::Error> {
+        let binding = RegisteredSequenceBinding::new(id, sequence, action, options);
+        self.register_sequence_binding(binding)
+    }
+
+    /// Register a [`RegisteredBinding`] with full options control.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::AlreadyRegistered`](crate::error::Error::AlreadyRegistered)
+    /// if a binding for the same hotkey exists.
+    pub fn register_binding(
+        &mut self,
+        binding: RegisteredBinding,
+    ) -> Result<(), crate::error::Error> {
+        let id = binding.id();
+        let hotkey = binding.hotkey().clone();
+
+        if self.bindings_by_id.contains_key(&id)
+            || self.sequence_bindings_by_id.contains_key(&id)
+            || self.binding_ids_by_hotkey.contains_key(&hotkey)
+        {
+            return Err(crate::error::Error::AlreadyRegistered);
+        }
+
+        self.binding_ids_by_hotkey.insert(hotkey, id);
+        self.bindings_by_id.insert(id, binding);
+        Ok(())
+    }
+
+    fn register_sequence_binding(
+        &mut self,
+        binding: RegisteredSequenceBinding,
+    ) -> Result<(), crate::error::Error> {
+        let id = binding.id;
+        let sequence = binding.sequence.clone();
+
+        if self.sequence_bindings_by_id.contains_key(&id)
+            || self.bindings_by_id.contains_key(&id)
+            || self.sequence_ids_by_value.contains_key(&sequence)
+        {
+            return Err(crate::error::Error::AlreadyRegistered);
+        }
+
+        self.sequence_ids_by_value.insert(sequence, id);
+        self.sequence_bindings_by_id.insert(id, binding);
+        Ok(())
+    }
+
+    /// Unregister a binding by its [`BindingId`].
+    pub fn unregister(&mut self, id: BindingId) {
+        if let Some(binding) = self.bindings_by_id.remove(&id) {
+            self.binding_ids_by_hotkey.remove(binding.hotkey());
+        }
+
+        if let Some(binding) = self.sequence_bindings_by_id.remove(&id) {
+            self.sequence_ids_by_value.remove(&binding.sequence);
+        }
+
+        self.active_sequences
+            .retain(|active| !matches!(active.binding_ref, SequenceBindingRef::Global(global_id) if global_id == id));
+
+        if self.pending_standalone.as_ref().is_some_and(|pending| {
+            matches!(
+                pending.binding_ref,
+                MatchedBindingRef::Global(global_id) | MatchedBindingRef::SequenceGlobal(global_id)
+                    if global_id == id
+            )
+        }) {
+            self.pending_standalone = None;
+        }
+
+        if self.active_sequences.is_empty() {
+            self.pending_standalone = None;
+        }
+    }
+
+    /// Check whether a hotkey has a registered global binding.
+    #[must_use]
+    pub fn is_registered(&self, hotkey: &Hotkey) -> bool {
+        self.binding_ids_by_hotkey.contains_key(hotkey)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::Dispatcher;
+    use crate::action::Action;
+    use crate::binding::BindingId;
+    use crate::binding::RegisteredBinding;
+    use crate::hotkey::Hotkey;
+    use crate::hotkey::HotkeySequence;
+    use crate::hotkey::Modifier;
+    use crate::key::Key;
+    use crate::sequence::SequenceOptions;
+
+    #[test]
+    fn register_returns_unique_id() {
+        let mut dispatcher = Dispatcher::new();
+        let id1 = dispatcher
+            .register(Hotkey::new(Key::A), Action::Suppress)
+            .unwrap();
+        let id2 = dispatcher
+            .register(Hotkey::new(Key::B), Action::Suppress)
+            .unwrap();
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn is_registered_reflects_state() {
+        let mut dispatcher = Dispatcher::new();
+        let hotkey = Hotkey::new(Key::C).modifier(Modifier::Ctrl);
+        assert!(!dispatcher.is_registered(&hotkey));
+
+        dispatcher
+            .register(hotkey.clone(), Action::Suppress)
+            .unwrap();
+        assert!(dispatcher.is_registered(&hotkey));
+    }
+
+    #[test]
+    fn register_sequence_accepts_typed_sequence() {
+        let mut dispatcher = Dispatcher::new();
+        let sequence = HotkeySequence::new(vec![
+            Hotkey::new(Key::K).modifier(Modifier::Ctrl),
+            Hotkey::new(Key::C).modifier(Modifier::Ctrl),
+        ])
+        .unwrap();
+
+        let id = dispatcher
+            .register_sequence(sequence, Action::Suppress)
+            .unwrap();
+        dispatcher.unregister(id);
+    }
+
+    #[test]
+    fn register_sequence_accepts_string_input() {
+        let mut dispatcher = Dispatcher::new();
+
+        let id = dispatcher
+            .register_sequence("Ctrl+K, Ctrl+C", Action::Suppress)
+            .unwrap();
+
+        dispatcher.unregister(id);
+    }
+
+    #[test]
+    fn register_sequence_accepts_vec_hotkeys_input() {
+        let mut dispatcher = Dispatcher::new();
+
+        let id = dispatcher
+            .register_sequence(
+                vec![
+                    Hotkey::new(Key::K).modifier(Modifier::Ctrl),
+                    Hotkey::new(Key::C).modifier(Modifier::Ctrl),
+                ],
+                Action::Suppress,
+            )
+            .unwrap();
+
+        dispatcher.unregister(id);
+    }
+
+    #[test]
+    fn register_sequence_reports_parse_error_for_string_input() {
+        let mut dispatcher = Dispatcher::new();
+
+        let result = dispatcher.register_sequence("Ctrl+K, Ctrl+Nope", Action::Suppress);
+
+        assert!(matches!(result, Err(crate::error::Error::Parse(_))));
+    }
+
+    #[test]
+    fn registering_sequence_with_existing_hotkey_id_is_rejected() {
+        let mut dispatcher = Dispatcher::new();
+        let id = BindingId::new();
+
+        dispatcher
+            .register_binding(RegisteredBinding::new(
+                id,
+                Hotkey::new(Key::A),
+                Action::Suppress,
+            ))
+            .unwrap();
+
+        let result = dispatcher.register_sequence_binding_with_id(
+            id,
+            "Ctrl+K, Ctrl+C".parse::<HotkeySequence>().unwrap(),
+            Action::Suppress,
+            SequenceOptions::default(),
+        );
+
+        assert!(matches!(
+            result,
+            Err(crate::error::Error::AlreadyRegistered)
+        ));
+    }
+
+    #[test]
+    fn registering_hotkey_with_existing_sequence_id_is_rejected() {
+        let mut dispatcher = Dispatcher::new();
+        let id = BindingId::new();
+
+        dispatcher
+            .register_sequence_binding_with_id(
+                id,
+                "Ctrl+K, Ctrl+C".parse::<HotkeySequence>().unwrap(),
+                Action::Suppress,
+                SequenceOptions::default(),
+            )
+            .unwrap();
+
+        let result = dispatcher.register_binding(RegisteredBinding::new(
+            id,
+            Hotkey::new(Key::A),
+            Action::Suppress,
+        ));
+
+        assert!(matches!(
+            result,
+            Err(crate::error::Error::AlreadyRegistered)
+        ));
+    }
+}

--- a/crates/kbd/src/dispatcher/sequence.rs
+++ b/crates/kbd/src/dispatcher/sequence.rs
@@ -388,8 +388,6 @@ mod tests {
     use super::super::Dispatcher;
     use super::super::MatchResult;
     use crate::action::Action;
-    use crate::binding::BindingId;
-    use crate::binding::RegisteredBinding;
     use crate::hotkey::Hotkey;
     use crate::hotkey::HotkeySequence;
     use crate::hotkey::Modifier;
@@ -407,57 +405,6 @@ mod tests {
         {
             callback();
         }
-    }
-
-    #[test]
-    fn register_sequence_accepts_typed_sequence() {
-        let mut dispatcher = Dispatcher::new();
-        let sequence = HotkeySequence::new(vec![
-            Hotkey::new(Key::K).modifier(Modifier::Ctrl),
-            Hotkey::new(Key::C).modifier(Modifier::Ctrl),
-        ])
-        .unwrap();
-
-        let id = dispatcher
-            .register_sequence(sequence, Action::Suppress)
-            .unwrap();
-        dispatcher.unregister(id);
-    }
-
-    #[test]
-    fn register_sequence_accepts_string_input() {
-        let mut dispatcher = Dispatcher::new();
-
-        let id = dispatcher
-            .register_sequence("Ctrl+K, Ctrl+C", Action::Suppress)
-            .unwrap();
-
-        dispatcher.unregister(id);
-    }
-
-    #[test]
-    fn register_sequence_accepts_vec_hotkeys_input() {
-        let mut dispatcher = Dispatcher::new();
-
-        let id = dispatcher
-            .register_sequence(
-                vec![
-                    Hotkey::new(Key::K).modifier(Modifier::Ctrl),
-                    Hotkey::new(Key::C).modifier(Modifier::Ctrl),
-                ],
-                Action::Suppress,
-            )
-            .unwrap();
-
-        dispatcher.unregister(id);
-    }
-
-    #[test]
-    fn register_sequence_reports_parse_error_for_string_input() {
-        let mut dispatcher = Dispatcher::new();
-
-        let result = dispatcher.register_sequence("Ctrl+K, Ctrl+Nope", Action::Suppress);
-        assert!(matches!(result, Err(crate::error::Error::Parse(_))));
     }
 
     #[test]
@@ -848,58 +795,6 @@ mod tests {
         execute_callback(&h);
 
         assert_eq!(counter.load(Ordering::Relaxed), 1);
-    }
-
-    #[test]
-    fn registering_sequence_with_existing_hotkey_id_is_rejected() {
-        let mut dispatcher = Dispatcher::new();
-        let id = BindingId::new();
-
-        dispatcher
-            .register_binding(RegisteredBinding::new(
-                id,
-                Hotkey::new(Key::A),
-                Action::Suppress,
-            ))
-            .unwrap();
-
-        let result = dispatcher.register_sequence_binding_with_id(
-            id,
-            "Ctrl+K, Ctrl+C".parse::<HotkeySequence>().unwrap(),
-            Action::Suppress,
-            SequenceOptions::default(),
-        );
-
-        assert!(matches!(
-            result,
-            Err(crate::error::Error::AlreadyRegistered)
-        ));
-    }
-
-    #[test]
-    fn registering_hotkey_with_existing_sequence_id_is_rejected() {
-        let mut dispatcher = Dispatcher::new();
-        let id = BindingId::new();
-
-        dispatcher
-            .register_sequence_binding_with_id(
-                id,
-                "Ctrl+K, Ctrl+C".parse::<HotkeySequence>().unwrap(),
-                Action::Suppress,
-                SequenceOptions::default(),
-            )
-            .unwrap();
-
-        let result = dispatcher.register_binding(RegisteredBinding::new(
-            id,
-            Hotkey::new(Key::A),
-            Action::Suppress,
-        ));
-
-        assert!(matches!(
-            result,
-            Err(crate::error::Error::AlreadyRegistered)
-        ));
     }
 
     #[test]


### PR DESCRIPTION
Mechanical move of registration, unregistration, and conflict-check logic from `dispatcher.rs` into a dedicated `dispatcher/registry.rs` submodule. Follows the established pattern (`layers.rs`, `timeout.rs`) of `impl Dispatcher` blocks in child modules.

## What moved to `dispatcher/registry.rs`

**Methods:**
- `register()`, `register_binding()` — global hotkey registration with conflict checks
- `register_sequence()`, `register_sequence_with_options()`, `register_sequence_binding_with_id()`, `register_sequence_binding()` — sequence registration chain
- `unregister()` — unified binding removal with sequence state cleanup
- `is_registered()` — hotkey presence query

**Tests:**
- `register_returns_unique_id` (from `dispatcher.rs`)
- `is_registered_reflects_state` (from `dispatcher.rs`)
- `register_sequence_accepts_typed_sequence` (from `sequence.rs`)
- `register_sequence_accepts_string_input` (from `sequence.rs`)
- `register_sequence_accepts_vec_hotkeys_input` (from `sequence.rs`)
- `register_sequence_reports_parse_error_for_string_input` (from `sequence.rs`)
- `registering_sequence_with_existing_hotkey_id_is_rejected` (from `sequence.rs`)
- `registering_hotkey_with_existing_sequence_id_is_rejected` (from `sequence.rs`)

## What stayed

Cross-cutting tests (e.g. unregister-during-pending-sequence) remain in their original modules.

## Verification

- No behavior changes, no public API changes
- 555 tests pass before and after (identical count on `main`)
- `just clippy` and `just fmt` clean
- `RUSTFLAGS="-D warnings" cargo check --all-targets` clean