### PR TITLE
chore(kbd): Extract shared candidate resolution helpers into dispatcher/resolve.rs

### DIFF
--- a/crates/kbd/src/dispatcher.rs
+++ b/crates/kbd/src/dispatcher.rs
@@ -11,6 +11,7 @@
 mod layers;
 mod query;
 mod registry;
+mod resolve;
 mod sequence;
 mod timeout;
 
@@ -19,11 +20,11 @@ use std::time::Instant;
 
 use self::layers::LayerEffect;
 use self::layers::LayerStackEntry;
+use self::resolve::ScopeSequenceMatch;
 use self::sequence::ActiveSequence;
 use self::sequence::PendingStandalone;
 use self::sequence::RegisteredSequenceBinding;
 use self::sequence::SequenceBindingRef;
-use self::sequence::SequencePrefixKind;
 use self::sequence::SequenceStartCandidate;
 use crate::action::Action;
 use crate::binding::BindingId;
@@ -316,39 +317,51 @@ impl Dispatcher {
                 continue;
             };
 
-            let mut candidates = Vec::new();
-            for (index, sequence_binding) in stored.sequence_bindings.iter().enumerate() {
-                match sequence::classify_sequence_prefix(&sequence_binding.sequence, hotkey) {
-                    SequencePrefixKind::None => {}
-                    SequencePrefixKind::SingleStep => {
-                        candidates.push(SequenceStartCandidate::SingleStep {
-                            binding_ref: MatchedBindingRef::SequenceLayer {
-                                name: layer_name.clone(),
-                                index,
-                            },
-                            layer_effect: LayerEffect::from_action(&sequence_binding.action),
-                            propagation: sequence_binding.propagation,
-                        });
-                    }
-                    SequencePrefixKind::MultiStep => {
-                        candidates.push(SequenceStartCandidate::MultiStep {
-                            binding_ref: SequenceBindingRef::Layer {
-                                name: layer_name.clone(),
-                                index,
-                            },
-                            timeout: sequence_binding.options.timeout(),
-                        });
-                    }
-                }
-            }
+            let scope_match = resolve::classify_scope_sequences(
+                stored.sequence_bindings.iter().map(|b| &b.sequence),
+                hotkey,
+            );
             let swallow_unmatched = matches!(stored.options.unmatched(), UnmatchedKeys::Swallow);
 
-            let pending_standalone =
-                self.pending_standalone_from_match(self.match_layer_hotkey(&layer_name, hotkey));
-            if let Some(outcome) =
-                self.start_sequences(candidates, now, next_priority, pending_standalone)
-            {
-                return Some(outcome);
+            // Build candidates from scope classification. Indices refer to
+            // positions in stored.sequence_bindings.
+            let candidates: Vec<_> = match &scope_match {
+                ScopeSequenceMatch::SingleStep { index } => {
+                    let sb = &stored.sequence_bindings[*index];
+                    vec![SequenceStartCandidate::SingleStep {
+                        binding_ref: MatchedBindingRef::SequenceLayer {
+                            name: layer_name.clone(),
+                            index: *index,
+                        },
+                        layer_effect: LayerEffect::from_action(&sb.action),
+                        propagation: sb.propagation,
+                    }]
+                }
+                ScopeSequenceMatch::MultiStep { indices } => indices
+                    .iter()
+                    .map(|&idx| {
+                        let sb = &stored.sequence_bindings[idx];
+                        SequenceStartCandidate::MultiStep {
+                            binding_ref: SequenceBindingRef::Layer {
+                                name: layer_name.clone(),
+                                index: idx,
+                            },
+                            timeout: sb.options.timeout(),
+                        }
+                    })
+                    .collect(),
+                ScopeSequenceMatch::None => Vec::new(),
+            };
+            // `stored` is last used above; NLL releases the borrow.
+
+            if !candidates.is_empty() {
+                let pending_standalone = self
+                    .pending_standalone_from_match(self.match_layer_hotkey(&layer_name, hotkey));
+                if let Some(outcome) =
+                    self.start_sequences(candidates, now, next_priority, pending_standalone)
+                {
+                    return Some(outcome);
+                }
             }
 
             if let Some((binding_ref, propagation)) = self.match_layer_hotkey(&layer_name, hotkey) {
@@ -373,44 +386,42 @@ impl Dispatcher {
         now: Instant,
         mut next_priority: usize,
     ) -> InternalOutcome {
-        let mut global_sequences: Vec<_> = self
-            .sequence_bindings_by_id
-            .values()
-            .filter(|binding| {
-                !matches!(
-                    sequence::classify_sequence_prefix(&binding.sequence, hotkey),
-                    SequencePrefixKind::None
-                )
-            })
-            .collect();
-        global_sequences.sort_by_key(|binding| binding.id.as_u64());
-
-        let mut candidates = Vec::new();
-        for binding in global_sequences {
-            match sequence::classify_sequence_prefix(&binding.sequence, hotkey) {
-                SequencePrefixKind::None => {}
-                SequencePrefixKind::SingleStep => {
-                    candidates.push(SequenceStartCandidate::SingleStep {
+        let candidates: Vec<SequenceStartCandidate> = {
+            let global_seqs = self.sorted_global_sequences();
+            let scope_match =
+                resolve::classify_scope_sequences(global_seqs.iter().map(|b| &b.sequence), hotkey);
+            match scope_match {
+                ScopeSequenceMatch::SingleStep { index } => {
+                    let binding = global_seqs[index];
+                    vec![SequenceStartCandidate::SingleStep {
                         binding_ref: MatchedBindingRef::SequenceGlobal(binding.id),
                         layer_effect: LayerEffect::from_action(&binding.action),
                         propagation: binding.propagation,
-                    });
+                    }]
                 }
-                SequencePrefixKind::MultiStep => {
-                    candidates.push(SequenceStartCandidate::MultiStep {
-                        binding_ref: SequenceBindingRef::Global(binding.id),
-                        timeout: binding.options.timeout(),
-                    });
-                }
+                ScopeSequenceMatch::MultiStep { indices } => indices
+                    .iter()
+                    .map(|&idx| {
+                        let binding = global_seqs[idx];
+                        SequenceStartCandidate::MultiStep {
+                            binding_ref: SequenceBindingRef::Global(binding.id),
+                            timeout: binding.options.timeout(),
+                        }
+                    })
+                    .collect(),
+                ScopeSequenceMatch::None => Vec::new(),
             }
-        }
+        };
+        // global_seqs dropped; self is unborrowed.
 
-        let pending_standalone =
-            self.pending_standalone_from_match(self.match_global_hotkey(hotkey));
-        if let Some(outcome) =
-            self.start_sequences(candidates, now, &mut next_priority, pending_standalone)
-        {
-            return outcome;
+        if !candidates.is_empty() {
+            let pending_standalone =
+                self.pending_standalone_from_match(self.match_global_hotkey(hotkey));
+            if let Some(outcome) =
+                self.start_sequences(candidates, now, &mut next_priority, pending_standalone)
+            {
+                return outcome;
+            }
         }
 
         if let Some((binding_ref, propagation)) = self.match_global_hotkey(hotkey) {

--- a/crates/kbd/src/dispatcher/query.rs
+++ b/crates/kbd/src/dispatcher/query.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
 
 use super::Dispatcher;
-use super::sequence;
-use super::sequence::RegisteredSequenceBinding;
-use super::sequence::SequencePrefixKind;
+use super::resolve;
+use super::resolve::ScopeSequenceMatch;
 use crate::hotkey::Hotkey;
 use crate::hotkey::Modifier;
 use crate::introspection::ActiveLayerInfo;
@@ -12,14 +11,7 @@ use crate::introspection::BindingLocation;
 use crate::introspection::ConflictInfo;
 use crate::introspection::ShadowedStatus;
 use crate::layer::LayerName;
-use crate::layer::StoredLayer;
 use crate::layer::UnmatchedKeys;
-
-enum SequenceQueryDecision {
-    None,
-    SingleStep(Hotkey),
-    MultiStep,
-}
 
 impl Dispatcher {
     /// Return a snapshot of all registered bindings with their status.
@@ -102,20 +94,25 @@ impl Dispatcher {
         // Sequence bindings are checked before immediate hotkeys.
         for entry in self.layer_stack.iter().rev() {
             if let Some(stored) = self.layers.get(&entry.name) {
-                match Self::probe_layer_sequence_prefix(stored, hotkey) {
-                    SequenceQueryDecision::None => {}
-                    SequenceQueryDecision::SingleStep(matched_hotkey) => {
+                let scope_match = resolve::classify_scope_sequences(
+                    stored.sequence_bindings.iter().map(|b| &b.sequence),
+                    hotkey,
+                );
+                match scope_match {
+                    ScopeSequenceMatch::SingleStep { index } => {
+                        let sb = &stored.sequence_bindings[index];
                         return Some(BindingInfo {
-                            hotkey: matched_hotkey,
+                            hotkey: sb.sequence.steps()[0].clone(),
                             description: None,
                             location: BindingLocation::Layer(entry.name.clone()),
                             shadowed: ShadowedStatus::Active,
                             overlay_visibility: crate::binding::OverlayVisibility::Visible,
                         });
                     }
-                    SequenceQueryDecision::MultiStep => {
+                    ScopeSequenceMatch::MultiStep { .. } => {
                         return None;
                     }
+                    ScopeSequenceMatch::None => {}
                 }
 
                 for binding in &stored.bindings {
@@ -139,32 +136,25 @@ impl Dispatcher {
         }
 
         // Global sequences are checked before global hotkeys, matching process().
-        let mut global_sequences: Vec<_> = self
-            .sequence_bindings_by_id
-            .values()
-            .filter(|binding| {
-                !matches!(
-                    sequence::classify_sequence_prefix(&binding.sequence, hotkey),
-                    SequencePrefixKind::None
-                )
-            })
-            .collect();
-        global_sequences.sort_by_key(|binding| binding.id.as_u64());
+        let global_seqs = self.sorted_global_sequences();
+        let scope_match =
+            resolve::classify_scope_sequences(global_seqs.iter().map(|b| &b.sequence), hotkey);
 
-        match Self::probe_global_sequence_prefix(&global_sequences, hotkey) {
-            SequenceQueryDecision::None => {}
-            SequenceQueryDecision::SingleStep(matched_hotkey) => {
+        match scope_match {
+            ScopeSequenceMatch::SingleStep { index } => {
+                let binding = global_seqs[index];
                 return Some(BindingInfo {
-                    hotkey: matched_hotkey,
+                    hotkey: binding.sequence.steps()[0].clone(),
                     description: None,
                     location: BindingLocation::Global,
                     shadowed: ShadowedStatus::Active,
                     overlay_visibility: crate::binding::OverlayVisibility::Visible,
                 });
             }
-            SequenceQueryDecision::MultiStep => {
+            ScopeSequenceMatch::MultiStep { .. } => {
                 return None;
             }
+            ScopeSequenceMatch::None => {}
         }
 
         // Fall through to global immediate bindings.
@@ -181,55 +171,6 @@ impl Dispatcher {
         }
 
         None
-    }
-
-    fn probe_layer_sequence_prefix(stored: &StoredLayer, hotkey: &Hotkey) -> SequenceQueryDecision {
-        let mut probe = SequenceQueryDecision::None;
-
-        for sequence_binding in &stored.sequence_bindings {
-            match sequence::classify_sequence_prefix(&sequence_binding.sequence, hotkey) {
-                SequencePrefixKind::None => {}
-                SequencePrefixKind::SingleStep => {
-                    probe = SequenceQueryDecision::SingleStep(
-                        sequence_binding.sequence.steps()[0].clone(),
-                    );
-                    break;
-                }
-                SequencePrefixKind::MultiStep => {
-                    if matches!(probe, SequenceQueryDecision::None) {
-                        probe = SequenceQueryDecision::MultiStep;
-                    }
-                }
-            }
-        }
-
-        probe
-    }
-
-    fn probe_global_sequence_prefix(
-        global_sequences: &[&RegisteredSequenceBinding],
-        hotkey: &Hotkey,
-    ) -> SequenceQueryDecision {
-        let mut probe = SequenceQueryDecision::None;
-
-        for sequence_binding in global_sequences {
-            match sequence::classify_sequence_prefix(&sequence_binding.sequence, hotkey) {
-                SequencePrefixKind::None => {}
-                SequencePrefixKind::SingleStep => {
-                    probe = SequenceQueryDecision::SingleStep(
-                        sequence_binding.sequence.steps()[0].clone(),
-                    );
-                    break;
-                }
-                SequencePrefixKind::MultiStep => {
-                    if matches!(probe, SequenceQueryDecision::None) {
-                        probe = SequenceQueryDecision::MultiStep;
-                    }
-                }
-            }
-        }
-
-        probe
     }
 
     /// Return the current layer stack (bottom to top).

--- a/crates/kbd/src/dispatcher/resolve.rs
+++ b/crates/kbd/src/dispatcher/resolve.rs
@@ -1,0 +1,96 @@
+use super::Dispatcher;
+use super::sequence::RegisteredSequenceBinding;
+use crate::hotkey::Hotkey;
+use crate::hotkey::HotkeySequence;
+
+/// Classification of a single sequence binding's first step against a hotkey.
+enum SequencePrefixKind {
+    /// The sequence's first step does not match the hotkey.
+    None,
+    /// The sequence is a single step and matches (immediate fire).
+    SingleStep,
+    /// The sequence has multiple steps and the first matches (enter pending).
+    MultiStep,
+}
+
+/// Classify whether a sequence's first step matches a given hotkey.
+fn classify_sequence_prefix(sequence: &HotkeySequence, hotkey: &Hotkey) -> SequencePrefixKind {
+    if !sequence
+        .steps()
+        .first()
+        .is_some_and(|first_step| first_step == hotkey)
+    {
+        return SequencePrefixKind::None;
+    }
+
+    if sequence.steps().len() == 1 {
+        SequencePrefixKind::SingleStep
+    } else {
+        SequencePrefixKind::MultiStep
+    }
+}
+
+/// Result of classifying all sequence bindings within a scope against a hotkey.
+///
+/// Encodes the precedence rule: single-step sequences win over multi-step.
+/// Indices refer to positions in the input iterator passed to
+/// [`classify_scope_sequences`].
+pub(super) enum ScopeSequenceMatch {
+    /// No sequences in this scope matched the hotkey as a prefix.
+    None,
+    /// A single-step sequence matched immediately (highest priority).
+    SingleStep { index: usize },
+    /// One or more multi-step sequences matched as prefixes (pending state).
+    MultiStep { indices: Vec<usize> },
+}
+
+/// Classify all sequence bindings in a scope against a hotkey.
+///
+/// Iterates the sequences, classifying each prefix. Returns the
+/// highest-priority match: `SingleStep` wins over `MultiStep`, which
+/// wins over `None`. For `MultiStep`, all matching indices are
+/// collected so the runtime can start them as active sequences.
+pub(super) fn classify_scope_sequences<'a>(
+    sequences: impl Iterator<Item = &'a HotkeySequence>,
+    hotkey: &Hotkey,
+) -> ScopeSequenceMatch {
+    let mut single_step_index: Option<usize> = None;
+    let mut multi_step_indices: Vec<usize> = Vec::new();
+
+    for (index, sequence) in sequences.enumerate() {
+        match classify_sequence_prefix(sequence, hotkey) {
+            SequencePrefixKind::None => {}
+            SequencePrefixKind::SingleStep => {
+                if single_step_index.is_none() {
+                    single_step_index = Some(index);
+                }
+            }
+            SequencePrefixKind::MultiStep => {
+                multi_step_indices.push(index);
+            }
+        }
+    }
+
+    if let Some(index) = single_step_index {
+        ScopeSequenceMatch::SingleStep { index }
+    } else if !multi_step_indices.is_empty() {
+        ScopeSequenceMatch::MultiStep {
+            indices: multi_step_indices,
+        }
+    } else {
+        ScopeSequenceMatch::None
+    }
+}
+
+impl Dispatcher {
+    /// Return all global sequence bindings sorted by ID for deterministic ordering.
+    ///
+    /// Both the runtime and query paths need globally-registered sequences in a
+    /// consistent order. This helper centralises the filter-free sort so callers
+    /// can pass the result straight to [`classify_scope_sequences`].
+    pub(super) fn sorted_global_sequences(&self) -> Vec<&RegisteredSequenceBinding> {
+        let mut seqs: Vec<_> = self.sequence_bindings_by_id.values().collect();
+        seqs.sort_by_key(|b| b.id.as_u64());
+        seqs
+    }
+}

--- a/crates/kbd/src/dispatcher/sequence.rs
+++ b/crates/kbd/src/dispatcher/sequence.rs
@@ -70,31 +70,6 @@ pub(super) enum SequenceStartCandidate {
     },
 }
 
-pub(super) enum SequencePrefixKind {
-    None,
-    SingleStep,
-    MultiStep,
-}
-
-pub(super) fn classify_sequence_prefix(
-    sequence: &HotkeySequence,
-    hotkey: &Hotkey,
-) -> SequencePrefixKind {
-    if !sequence
-        .steps()
-        .first()
-        .is_some_and(|first_step| first_step == hotkey)
-    {
-        return SequencePrefixKind::None;
-    }
-
-    if sequence.steps().len() == 1 {
-        SequencePrefixKind::SingleStep
-    } else {
-        SequencePrefixKind::MultiStep
-    }
-}
-
 impl Dispatcher {
     pub(super) fn match_active_sequences(&mut self, hotkey: &Hotkey) -> Option<InternalOutcome> {
         if self.active_sequences.is_empty() {


### PR DESCRIPTION
Unify the sequence-vs-hotkey precedence logic that was independently implemented in both the runtime (`dispatcher.rs` `match_layers`/`match_globals`) and query path (`query.rs` `probe_layer_sequence_prefix`/`probe_global_sequence_prefix`).

## What changed

New shared helpers in `resolve.rs`:
- `classify_scope_sequences()`: determines what kind of sequence match exists within a scope (SingleStep immediate, MultiStep pending, or None). Encodes the precedence rule once: SingleStep > MultiStep.
- `sorted_global_sequences()`: centralises the sort of global sequence bindings by ID for deterministic ordering.

Removed from `query.rs`:
- `SequenceQueryDecision` enum (replaced by `ScopeSequenceMatch`)
- `probe_layer_sequence_prefix()` (replaced by `classify_scope_sequences`)
- `probe_global_sequence_prefix()` (replaced by `classify_scope_sequences`)

Moved from `sequence.rs` to `resolve.rs` (now private):
- `SequencePrefixKind` enum
- `classify_sequence_prefix()` function

## Why

Both the runtime dispatch and introspection query paths independently implemented the same sequence-vs-hotkey precedence logic. This meant any change to precedence rules had to be made in two places. Now both paths call through the same shared helpers.

## Verification

- Pure structural refactor — no public API changes, no behavior changes
- All existing tests pass (`cargo test --workspace`)
- `just clippy` and `just fmt` clean
- Net -73 lines removed (192 added, 169 removed across the extraction)