### PR TITLE
feat(kbd): Add sequence step progress reporting to dispatcher

### DIFF
--- a/crates/kbd/README.md
+++ b/crates/kbd/README.md
@@ -27,7 +27,7 @@ assert!(matches!(result, MatchResult::Matched { .. }));
 # Ok::<(), kbd::error::Error>(())
 ```
 
-Supports [layers](https://docs.rs/kbd/latest/kbd/layer/), [introspection](https://docs.rs/kbd/latest/kbd/introspection/), and optional `serde`. See the [API docs](https://docs.rs/kbd) for the full picture.
+Supports [layers](https://docs.rs/kbd/latest/kbd/layer/), [introspection](https://docs.rs/kbd/latest/kbd/introspection/), sequence-progress reporting via [`Dispatcher::drain_sequence_steps`](https://docs.rs/kbd/latest/kbd/dispatcher/struct.Dispatcher.html#method.drain_sequence_steps), and optional `serde`. See the [API docs](https://docs.rs/kbd) for the full picture.
 
 ## License
 

--- a/crates/kbd/src/dispatcher.rs
+++ b/crates/kbd/src/dispatcher.rs
@@ -39,6 +39,7 @@ use crate::layer::LayerName;
 use crate::layer::StoredLayer;
 use crate::layer::UnmatchedKeys;
 use crate::sequence::PendingSequenceInfo;
+use crate::sequence::SequenceStepInfo;
 
 /// Result of attempting to match a key event against registered bindings.
 #[derive(Debug)]
@@ -161,6 +162,7 @@ pub struct Dispatcher {
     layer_stack: Vec<LayerStackEntry>,
     active_sequences: Vec<ActiveSequence>,
     pending_standalone: Option<PendingStandalone>,
+    sequence_steps: Vec<SequenceStepInfo>,
 }
 
 /// Internal reference to a matched binding, used to re-find the action
@@ -202,6 +204,17 @@ impl Dispatcher {
         self.pending_sequence_snapshot()
     }
 
+    /// Drain sequence step matches from the latest dispatch work.
+    ///
+    /// Consumers that care about sequence progress should call this promptly
+    /// after each [`process`](Self::process) or timeout check they want to
+    /// observe. Older undrained step records are discarded when a new dispatch
+    /// cycle starts so the dispatcher does not accumulate unbounded event state.
+    #[must_use]
+    pub fn drain_sequence_steps(&mut self) -> Vec<SequenceStepInfo> {
+        std::mem::take(&mut self.sequence_steps)
+    }
+
     /// Define a named layer. The layer is not active until pushed.
     ///
     /// # Errors
@@ -236,6 +249,7 @@ impl Dispatcher {
     /// return `MatchResult::Ignored`. Modifier-only presses also return
     /// `MatchResult::Ignored`.
     pub fn process(&mut self, hotkey: &Hotkey, transition: KeyTransition) -> MatchResult<'_> {
+        self.sequence_steps.clear();
         let outcome = self.match_extract(hotkey, transition);
 
         if let InternalOutcome::Matched {
@@ -340,7 +354,7 @@ impl Dispatcher {
                         propagation: sb.propagation,
                     }];
                     if let Some(outcome) =
-                        self.start_sequences(candidates, now, next_priority, None)
+                        self.start_sequences(candidates, hotkey, now, next_priority, None)
                     {
                         return Some(outcome);
                     }
@@ -375,9 +389,13 @@ impl Dispatcher {
                         }
                     });
                     // `stored` is last used above; NLL releases the borrow.
-                    if let Some(outcome) =
-                        self.start_sequences(candidates, now, next_priority, pending_standalone)
-                    {
+                    if let Some(outcome) = self.start_sequences(
+                        candidates,
+                        hotkey,
+                        now,
+                        next_priority,
+                        pending_standalone,
+                    ) {
                         return Some(outcome);
                     }
                 }
@@ -445,9 +463,13 @@ impl Dispatcher {
         if !candidates.is_empty() {
             let pending_standalone =
                 self.pending_standalone_from_match(self.match_global_hotkey(hotkey));
-            if let Some(outcome) =
-                self.start_sequences(candidates, now, &mut next_priority, pending_standalone)
-            {
+            if let Some(outcome) = self.start_sequences(
+                candidates,
+                hotkey,
+                now,
+                &mut next_priority,
+                pending_standalone,
+            ) {
                 return outcome;
             }
         }

--- a/crates/kbd/src/dispatcher/resolve.rs
+++ b/crates/kbd/src/dispatcher/resolve.rs
@@ -205,6 +205,7 @@ mod tests {
 
     fn seq_binding(sequence: HotkeySequence) -> LayerSequenceBinding {
         LayerSequenceBinding {
+            id: crate::binding::BindingId::new(),
             sequence,
             action: Action::Suppress,
             propagation: KeyPropagation::default(),

--- a/crates/kbd/src/dispatcher/sequence.rs
+++ b/crates/kbd/src/dispatcher/sequence.rs
@@ -13,6 +13,7 @@ use crate::hotkey::HotkeySequence;
 use crate::layer::LayerName;
 use crate::sequence::PendingSequenceInfo;
 use crate::sequence::SequenceOptions;
+use crate::sequence::SequenceStepInfo;
 
 pub(super) struct RegisteredSequenceBinding {
     pub(super) id: BindingId,
@@ -92,6 +93,12 @@ impl Dispatcher {
             if self.sequence_step_matches(&active.binding_ref, active.next_step_index, hotkey) {
                 active.next_step_index += 1;
                 let total = self.sequence_step_count(&active.binding_ref);
+                self.record_sequence_step(
+                    &active.binding_ref,
+                    hotkey,
+                    active.next_step_index,
+                    total,
+                );
                 if active.next_step_index >= total {
                     completed.push((active.priority, active.binding_ref));
                 } else {
@@ -151,6 +158,7 @@ impl Dispatcher {
     pub(super) fn start_sequences(
         &mut self,
         candidates: Vec<SequenceStartCandidate>,
+        hotkey: &Hotkey,
         now: Instant,
         next_priority: &mut usize,
         pending_standalone: Option<PendingStandalone>,
@@ -167,6 +175,7 @@ impl Dispatcher {
                     layer_effect,
                     propagation,
                 } => {
+                    self.record_single_step_sequence(&binding_ref, hotkey);
                     self.active_sequences.clear();
                     self.pending_standalone = None;
                     return Some(InternalOutcome::Matched {
@@ -179,6 +188,8 @@ impl Dispatcher {
                     binding_ref,
                     timeout,
                 } => {
+                    let total = self.sequence_step_count(&binding_ref);
+                    self.record_sequence_step(&binding_ref, hotkey, 1, total);
                     started.push(ActiveSequence {
                         binding_ref,
                         next_step_index: 1,
@@ -316,6 +327,51 @@ impl Dispatcher {
             .max_by_key(|pending| pending.steps_matched)
     }
 
+    fn record_sequence_step(
+        &mut self,
+        binding_ref: &SequenceBindingRef,
+        hotkey: &Hotkey,
+        steps_matched: usize,
+        total_steps: usize,
+    ) {
+        self.sequence_steps.push(SequenceStepInfo {
+            binding_id: self.sequence_binding_id(binding_ref),
+            hotkey: hotkey.clone(),
+            steps_matched,
+            steps_remaining: total_steps.saturating_sub(steps_matched),
+        });
+    }
+
+    fn record_single_step_sequence(&mut self, binding_ref: &MatchedBindingRef, hotkey: &Hotkey) {
+        self.sequence_steps.push(SequenceStepInfo {
+            binding_id: self.sequence_binding_id_from_match(binding_ref),
+            hotkey: hotkey.clone(),
+            steps_matched: 1,
+            steps_remaining: 0,
+        });
+    }
+
+    fn sequence_binding_id(&self, binding_ref: &SequenceBindingRef) -> BindingId {
+        match binding_ref {
+            SequenceBindingRef::Global(id) => *id,
+            SequenceBindingRef::Layer { name, index } => {
+                self.layers[name].sequence_bindings[*index].id
+            }
+        }
+    }
+
+    fn sequence_binding_id_from_match(&self, binding_ref: &MatchedBindingRef) -> BindingId {
+        match binding_ref {
+            MatchedBindingRef::SequenceGlobal(id) => *id,
+            MatchedBindingRef::SequenceLayer { name, index } => {
+                self.layers[name].sequence_bindings[*index].id
+            }
+            MatchedBindingRef::Global(_) | MatchedBindingRef::Layer { .. } => {
+                unreachable!("single-step sequence tracking only records sequence bindings")
+            }
+        }
+    }
+
     pub(super) fn clear_sequences_for_layer_if_inactive(&mut self, layer_name: &LayerName) {
         if self
             .layer_stack
@@ -371,6 +427,7 @@ mod tests {
     use crate::layer::Layer;
     use crate::layer::LayerName;
     use crate::sequence::SequenceOptions;
+    use crate::sequence::SequenceStepInfo;
 
     fn execute_callback(result: &MatchResult<'_>) {
         if let MatchResult::Matched {
@@ -792,5 +849,84 @@ mod tests {
         let pending = dispatcher.pending_sequence().expect("pending sequence");
         assert_eq!(pending.steps_matched, 1);
         assert_eq!(pending.steps_remaining, 1);
+    }
+
+    #[test]
+    fn drain_sequence_steps_reports_each_matched_step() {
+        let mut dispatcher = Dispatcher::new();
+        let binding_id = dispatcher
+            .register_sequence("Ctrl+K, Ctrl+C", Action::Suppress)
+            .expect("sequence should register");
+
+        let first = dispatcher.process(
+            &Hotkey::new(Key::K).modifier(Modifier::Ctrl),
+            KeyTransition::Press,
+        );
+        assert!(matches!(first, MatchResult::Pending { .. }));
+        assert_eq!(
+            dispatcher.drain_sequence_steps(),
+            vec![SequenceStepInfo {
+                binding_id,
+                hotkey: Hotkey::new(Key::K).modifier(Modifier::Ctrl),
+                steps_matched: 1,
+                steps_remaining: 1,
+            }]
+        );
+
+        let second = dispatcher.process(
+            &Hotkey::new(Key::C).modifier(Modifier::Ctrl),
+            KeyTransition::Press,
+        );
+        assert!(matches!(second, MatchResult::Matched { .. }));
+        assert_eq!(
+            dispatcher.drain_sequence_steps(),
+            vec![SequenceStepInfo {
+                binding_id,
+                hotkey: Hotkey::new(Key::C).modifier(Modifier::Ctrl),
+                steps_matched: 2,
+                steps_remaining: 0,
+            }]
+        );
+    }
+
+    #[test]
+    fn stale_sequence_steps_are_discarded_on_next_dispatch_cycle() {
+        let mut dispatcher = Dispatcher::new();
+        dispatcher
+            .register_sequence("Ctrl+K, Ctrl+C", Action::Suppress)
+            .expect("sequence should register");
+
+        let first = dispatcher.process(
+            &Hotkey::new(Key::K).modifier(Modifier::Ctrl),
+            KeyTransition::Press,
+        );
+        assert!(matches!(first, MatchResult::Pending { .. }));
+
+        let no_match = dispatcher.process(&Hotkey::new(Key::X), KeyTransition::Press);
+        assert!(matches!(no_match, MatchResult::NoMatch));
+        assert!(dispatcher.drain_sequence_steps().is_empty());
+    }
+
+    #[test]
+    fn drain_sequence_steps_reports_single_step_sequence_completion() {
+        let mut dispatcher = Dispatcher::new();
+        let binding_id = dispatcher
+            .register_sequence("Ctrl+K", Action::Suppress)
+            .expect("sequence should register");
+
+        let result = dispatcher.process(
+            &Hotkey::new(Key::K).modifier(Modifier::Ctrl),
+            KeyTransition::Press,
+        );
+        assert!(matches!(result, MatchResult::Matched { .. }));
+        assert_eq!(
+            dispatcher.drain_sequence_steps(),
+            vec![SequenceStepInfo {
+                binding_id,
+                hotkey: Hotkey::new(Key::K).modifier(Modifier::Ctrl),
+                steps_matched: 1,
+                steps_remaining: 0,
+            }]
+        );
     }
 }

--- a/crates/kbd/src/dispatcher/timeout.rs
+++ b/crates/kbd/src/dispatcher/timeout.rs
@@ -45,6 +45,7 @@ impl Dispatcher {
 
     /// Check timeout-driven state transitions and return any timeout matches.
     pub fn check_timeouts_with_results(&mut self) -> Vec<MatchResult<'_>> {
+        self.sequence_steps.clear();
         let now = Instant::now();
 
         let mut timed_out_layers = Vec::new();
@@ -112,6 +113,7 @@ mod tests {
     use super::super::MatchResult;
     use crate::action::Action;
     use crate::hotkey::Hotkey;
+    use crate::hotkey::Modifier;
     use crate::key::Key;
     use crate::key_state::KeyTransition;
     use crate::layer::Layer;
@@ -159,5 +161,23 @@ mod tests {
         // Second press → layer should be gone now
         let result = dispatcher.process(&Hotkey::new(Key::H), KeyTransition::Press);
         assert!(matches!(result, MatchResult::NoMatch));
+    }
+
+    #[test]
+    fn timeout_checks_discard_undrained_sequence_steps_from_prior_dispatch() {
+        let mut dispatcher = Dispatcher::new();
+        dispatcher
+            .register_sequence("Ctrl+K, Ctrl+C", Action::Suppress)
+            .unwrap();
+
+        let first = dispatcher.process(
+            &Hotkey::new(Key::K).modifier(Modifier::Ctrl),
+            KeyTransition::Press,
+        );
+        assert!(matches!(first, MatchResult::Pending { .. }));
+
+        let timeout_results = dispatcher.check_timeouts_with_results();
+        assert!(timeout_results.is_empty());
+        assert!(dispatcher.drain_sequence_steps().is_empty());
     }
 }

--- a/crates/kbd/src/layer.rs
+++ b/crates/kbd/src/layer.rs
@@ -15,6 +15,7 @@
 use std::time::Duration;
 
 use crate::action::Action;
+use crate::binding::BindingId;
 use crate::binding::KeyPropagation;
 use crate::error::ParseHotkeyError;
 use crate::hotkey::Hotkey;
@@ -162,6 +163,7 @@ pub(crate) struct LayerBinding {
 /// A single sequence binding within a layer.
 #[derive(Debug)]
 pub(crate) struct LayerSequenceBinding {
+    pub(crate) id: BindingId,
     pub(crate) sequence: HotkeySequence,
     pub(crate) action: Action,
     pub(crate) propagation: KeyPropagation,
@@ -297,6 +299,7 @@ impl Layer {
         action: impl Into<Action>,
     ) -> Result<Self, ParseHotkeyError> {
         self.sequence_bindings.push(LayerSequenceBinding {
+            id: BindingId::new(),
             sequence: sequence.into_sequence()?,
             action: action.into(),
             propagation: KeyPropagation::default(),
@@ -317,6 +320,7 @@ impl Layer {
         options: SequenceOptions,
     ) -> Result<Self, ParseHotkeyError> {
         self.sequence_bindings.push(LayerSequenceBinding {
+            id: BindingId::new(),
             sequence: sequence.into_sequence()?,
             action: action.into(),
             propagation: KeyPropagation::default(),

--- a/crates/kbd/src/lib.rs
+++ b/crates/kbd/src/lib.rs
@@ -34,6 +34,42 @@
 //! # }
 //! ```
 //!
+//! # Sequence progress
+//!
+//! Multi-step sequences can report progress between keystrokes. After each
+//! [`Dispatcher::process`] call, drain any recorded sequence steps with
+//! [`Dispatcher::drain_sequence_steps`]:
+//!
+//! ```
+//! use kbd::action::Action;
+//! use kbd::dispatcher::{Dispatcher, MatchResult};
+//! use kbd::hotkey::{Hotkey, Modifier};
+//! use kbd::key::Key;
+//! use kbd::key_state::KeyTransition;
+//! use kbd::sequence::SequenceStepInfo;
+//!
+//! # fn main() -> Result<(), kbd::error::Error> {
+//! let mut dispatcher = Dispatcher::new();
+//! let binding_id = dispatcher.register_sequence("Ctrl+K, Ctrl+C", Action::Suppress)?;
+//!
+//! let pending = dispatcher.process(
+//!     &Hotkey::new(Key::K).modifier(Modifier::Ctrl),
+//!     KeyTransition::Press,
+//! );
+//! assert!(matches!(pending, MatchResult::Pending { .. }));
+//! assert_eq!(
+//!     dispatcher.drain_sequence_steps(),
+//!     vec![SequenceStepInfo {
+//!         binding_id,
+//!         hotkey: Hotkey::new(Key::K).modifier(Modifier::Ctrl),
+//!         steps_matched: 1,
+//!         steps_remaining: 1,
+//!     }]
+//! );
+//! # Ok(())
+//! # }
+//! ```
+//!
 //! # Feature Flags
 //!
 //! | Flag | Default | Effect |

--- a/crates/kbd/src/sequence.rs
+++ b/crates/kbd/src/sequence.rs
@@ -2,6 +2,7 @@
 
 use std::time::Duration;
 
+use crate::binding::BindingId;
 use crate::error::ParseHotkeyError;
 use crate::hotkey::Hotkey;
 use crate::hotkey::HotkeySequence;
@@ -108,6 +109,19 @@ pub struct PendingSequenceInfo {
     /// Number of steps already matched.
     pub steps_matched: usize,
     /// Number of steps still required to complete.
+    pub steps_remaining: usize,
+}
+
+/// A sequence step that matched during dispatch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SequenceStepInfo {
+    /// The binding whose sequence advanced.
+    pub binding_id: BindingId,
+    /// The hotkey that matched this step.
+    pub hotkey: Hotkey,
+    /// Number of steps matched so far, including this step.
+    pub steps_matched: usize,
+    /// Number of steps remaining after this step.
     pub steps_remaining: usize,
 }
 


### PR DESCRIPTION
Extracted from the abandoned `feature/sequence-step-events` branch — just the `kbd` core-side changes, no `kbd-global` event stream (that belongs in §4.6).

## What this adds

- `SequenceStepInfo` struct in `kbd::sequence` — records binding ID, matched hotkey, steps matched, and steps remaining
- `Dispatcher::drain_sequence_steps()` — consumers call this after each `process()` or timeout check to collect step progress
- Steps are cleared at the start of each dispatch cycle so undrained records don't accumulate
- `LayerSequenceBinding` now carries a `BindingId` so step events can identify which binding advanced

## What this does NOT add

The `kbd-global` event stream (`HotkeyEvent`, `HotkeyEventStream`, subscriber management, `async-channel` dependency) was premature — it belongs in §4.6 with proper feature-gated `tokio`/`async-std` support per the plan.

Completes §4.1 (key sequences).